### PR TITLE
Feature involve top22 25 prods in schedule

### DIFF
--- a/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
+++ b/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
@@ -231,17 +231,13 @@ namespace eosiosystem {
     * Defines new global state parameters to store inflation rate and distribution
     */
    struct [[eosio::table("rotations"), eosio::contract("rem.system")]] rotation_state {
-      std::deque<name>  prods_by_rotation_time;
-      std::deque<name>  standby_prods_by_rotation_time;
+      time_point   last_rotation_time;
+      microseconds rotation_period;
+      uint32_t     standby_prods_to_rotate;
 
-      name              bp_out;
-      name              sbp_in;
-      time_point        last_rotation_time;
-      microseconds      rotation_period;
-      uint32_t          standby_prods_to_rotate;
+      std::vector<eosio::producer_key>  standby_rotation;
 
-      EOSLIB_SERIALIZE( rotation_state, (prods_by_rotation_time)(standby_prods_by_rotation_time)
-         (bp_out)(sbp_in)(last_rotation_time)(rotation_period)(standby_prods_to_rotate) )
+      EOSLIB_SERIALIZE( rotation_state, (last_rotation_time)(rotation_period)(standby_prods_to_rotate)(standby_rotation) )
    };
 
    /**

--- a/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
+++ b/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
@@ -206,9 +206,8 @@ namespace eosiosystem {
     * Defines new global state parameters to store remme specific parameters
     */
    struct [[eosio::table("globalrem"), eosio::contract("rem.system")]] eosio_global_rem_state {
-      eosio_global_rem_state() { }
-      double  per_stake_share;
-      double  per_vote_share;
+      double  per_stake_share = 0.6;
+      double  per_vote_share  = 0.3;
 
       name gifter_attr_contract = name{"rem.attr"};
       name gifter_attr_issuer   = name{"rem.attr"};
@@ -216,7 +215,7 @@ namespace eosiosystem {
 
       int64_t producer_stake_threshold = 250'000'0000LL;
 
-      microseconds stake_lock_period = eosio::days(180);
+      microseconds stake_lock_period   = eosio::days(180);
       microseconds stake_unlock_period = eosio::days(180);
 
       microseconds reassertion_period = eosio::days( 7 );

--- a/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
+++ b/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
@@ -228,7 +228,7 @@ namespace eosiosystem {
    };
 
    /**
-    * Defines new global state parameters to store inflation rate and distribution
+    * Defines new global state parameters to producer schedule rotation
     */
    struct [[eosio::table("rotations"), eosio::contract("rem.system")]] rotation_state {
       time_point   last_rotation_time;
@@ -1447,7 +1447,7 @@ namespace eosiosystem {
 
          // Block producer should reassert its status (via voting) every reassertion_period days
          bool vote_is_reasserted( eosio::time_point last_reassertion_time ) const;
-         
+
          //defined in rotation.cpp
          std::vector<eosio::producer_key> get_rotated_schedule();
 

--- a/contracts/contracts/rem.system/src/producer_pay.cpp
+++ b/contracts/contracts/rem.system/src/producer_pay.cpp
@@ -135,47 +135,6 @@ namespace eosiosystem {
             });
          }
          update_pervote_shares();
-
-         //TODO: update prods_by_rotation_time and standby_prods_by_rotation_time
-         auto sortedprods = _producers.get_index<"prototalvote"_n>();
-         std::vector<name> top_prods;
-         std::vector<name> rotating_standby;
-         std::deque<name> prods_by_rotation_time;
-         std::deque<name> standby_prods_by_rotation_time;
-         top_prods.reserve(max_block_producers);
-         auto prod_it = sortedprods.begin();
-         for (; top_prods.size() < max_block_producers &&
-                prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
-            top_prods.push_back(prod_it->owner);
-            if (std::find(std::begin(_grotation.prods_by_rotation_time), std::end(_grotation.prods_by_rotation_time), prod_it->owner) ==
-                  std::end(_grotation.prods_by_rotation_time)) {
-               //insert new producers
-               prods_by_rotation_time.push_back(prod_it->owner);
-            }
-         }
-         if (top_prods.size() == max_block_producers) {
-            for (; rotating_standby.size() < _grotation.standby_prods_to_rotate &&
-                   prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
-               rotating_standby.push_back(prod_it->owner);
-               if (std::find(std::begin(_grotation.standby_prods_by_rotation_time), std::end(_grotation.standby_prods_by_rotation_time), prod_it->owner) ==
-                     std::end(_grotation.standby_prods_by_rotation_time)) {
-                  //insert new standby producers
-                  standby_prods_by_rotation_time.push_back(prod_it->owner);
-               }
-            }
-         }
-         for (auto it = std::rbegin(_grotation.prods_by_rotation_time); it != std::rend(_grotation.prods_by_rotation_time); it++) {
-            if (std::find(std::begin(top_prods), std::end(top_prods), *it) != std::end(top_prods)) {
-               prods_by_rotation_time.push_front(*it);
-            }
-         }
-         for (auto it = std::rbegin(_grotation.standby_prods_by_rotation_time); it != std::rend(_grotation.standby_prods_by_rotation_time); it++) {
-            if (std::find(std::begin(rotating_standby), std::end(rotating_standby), *it) != std::end(rotating_standby)) {
-               standby_prods_by_rotation_time.push_front(*it);
-            }
-         }
-         _grotation.prods_by_rotation_time = prods_by_rotation_time;
-         _grotation.standby_prods_by_rotation_time = standby_prods_by_rotation_time;
       }
 
       if( _gstate.last_pervote_bucket_fill == time_point() )  /// start the presses

--- a/contracts/contracts/rem.system/src/producer_pay.cpp
+++ b/contracts/contracts/rem.system/src/producer_pay.cpp
@@ -18,9 +18,8 @@ namespace eosiosystem {
    const int64_t  useconds_per_day      = 24 * 3600 * int64_t(1000000);
    const int64_t  useconds_per_year     = seconds_per_year*1000000ll;
 
-   const static int producer_count = 21;
    const static int producer_repetitions = 12;
-   const static int blocks_per_round = producer_count * producer_repetitions;
+   const static int blocks_per_round = system_contract::max_block_producers * producer_repetitions;
 
 
    int64_t system_contract::share_pervote_reward_between_producers(int64_t amount)

--- a/contracts/contracts/rem.system/src/producer_pay.cpp
+++ b/contracts/contracts/rem.system/src/producer_pay.cpp
@@ -135,6 +135,47 @@ namespace eosiosystem {
             });
          }
          update_pervote_shares();
+
+         //TODO: update prods_by_rotation_time and standby_prods_by_rotation_time
+         auto sortedprods = _producers.get_index<"prototalvote"_n>();
+         std::vector<name> top_prods;
+         std::vector<name> rotating_standby;
+         std::deque<name> prods_by_rotation_time;
+         std::deque<name> standby_prods_by_rotation_time;
+         top_prods.reserve(max_block_producers);
+         auto prod_it = sortedprods.begin();
+         for (; top_prods.size() < max_block_producers &&
+                prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
+            top_prods.push_back(prod_it->owner);
+            if (std::find(std::begin(_grotation.prods_by_rotation_time), std::end(_grotation.prods_by_rotation_time), prod_it->owner) ==
+                  std::end(_grotation.prods_by_rotation_time)) {
+               //insert new producers
+               prods_by_rotation_time.push_back(prod_it->owner);
+            }
+         }
+         if (top_prods.size() == max_block_producers) {
+            for (; rotating_standby.size() < _grotation.standby_prods_to_rotate &&
+                   prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
+               rotating_standby.push_back(prod_it->owner);
+               if (std::find(std::begin(_grotation.standby_prods_by_rotation_time), std::end(_grotation.standby_prods_by_rotation_time), prod_it->owner) ==
+                     std::end(_grotation.standby_prods_by_rotation_time)) {
+                  //insert new standby producers
+                  standby_prods_by_rotation_time.push_back(prod_it->owner);
+               }
+            }
+         }
+         for (auto it = std::rbegin(_grotation.prods_by_rotation_time); it != std::rend(_grotation.prods_by_rotation_time); it++) {
+            if (std::find(std::begin(top_prods), std::end(top_prods), *it) != std::end(top_prods)) {
+               prods_by_rotation_time.push_front(*it);
+            }
+         }
+         for (auto it = std::rbegin(_grotation.standby_prods_by_rotation_time); it != std::rend(_grotation.standby_prods_by_rotation_time); it++) {
+            if (std::find(std::begin(rotating_standby), std::end(rotating_standby), *it) != std::end(rotating_standby)) {
+               standby_prods_by_rotation_time.push_front(*it);
+            }
+         }
+         _grotation.prods_by_rotation_time = prods_by_rotation_time;
+         _grotation.standby_prods_by_rotation_time = standby_prods_by_rotation_time;
       }
 
       if( _gstate.last_pervote_bucket_fill == time_point() )  /// start the presses

--- a/contracts/contracts/rem.system/src/rem.system.cpp
+++ b/contracts/contracts/rem.system/src/rem.system.cpp
@@ -53,7 +53,7 @@ namespace eosiosystem {
       _gremstate = _globalrem.exists() ? _globalrem.get() : get_default_rem_parameters();
 
       _grotation = _rotation.get_or_create(_self, rotation_state{
-         .last_rotation_time      = time_point(),
+         .last_rotation_time      = time_point{},
          .rotation_period         = eosio::hours(4),
          .standby_prods_to_rotate = 4
       });

--- a/contracts/contracts/rem.system/src/rem.system.cpp
+++ b/contracts/contracts/rem.system/src/rem.system.cpp
@@ -74,11 +74,23 @@ namespace eosiosystem {
    }
 
    eosio_global_rem_state system_contract::get_default_rem_parameters() {
-      eosio_global_rem_state gs;
-      gs.per_stake_share = 0.6;
-      gs.per_vote_share = 0.3;
+      const auto rem_state = eosio_global_rem_state{
+         .per_stake_share = 0.6,
+         .per_vote_share = 0.3,
 
-      return gs;
+         .gifter_attr_contract = name{"rem.attr"},
+         .gifter_attr_issuer   = name{"rem.attr"},
+         .gifter_attr_name     = name{"accgifter"},
+
+         .producer_stake_threshold = 250'000'0000LL,
+
+         .stake_lock_period = eosio::days(180),
+         .stake_unlock_period = eosio::days(180),
+
+         .reassertion_period = eosio::days( 7 )
+      };
+
+      return rem_state;
    }
 
    symbol system_contract::core_symbol()const {

--- a/contracts/contracts/rem.system/src/rem.system.cpp
+++ b/contracts/contracts/rem.system/src/rem.system.cpp
@@ -14,6 +14,7 @@
 #include "voting.cpp"
 #include "exchange_state.cpp"
 #include "rex.cpp"
+#include "rotation.cpp"
 
 namespace eosiosystem {
 
@@ -38,6 +39,7 @@ namespace eosiosystem {
     _global4(_self, _self.value),
     _globalrem(_self, _self.value),
     _rammarket(_self, _self.value),
+    _rotation(_self, _self.value),
     _rexpool(_self, _self.value),
     _rexfunds(_self, _self.value),
     _rexbalance(_self, _self.value),
@@ -49,6 +51,12 @@ namespace eosiosystem {
       _gstate3 = _global3.exists() ? _global3.get() : eosio_global_state3{};
       _gstate4 = _global4.exists() ? _global4.get() : get_default_inflation_parameters();
       _gremstate = _globalrem.exists() ? _globalrem.get() : get_default_rem_parameters();
+
+      _grotation = _rotation.get_or_create(_self, rotation_state{
+         .last_rotation_time      = time_point(),
+         .rotation_period         = eosio::hours(4),
+         .standby_prods_to_rotate = 4
+      });
    }
 
    eosio_global_state system_contract::get_default_parameters() {
@@ -84,6 +92,7 @@ namespace eosiosystem {
       _global3.set( _gstate3, _self );
       _global4.set( _gstate4, _self );
       _globalrem.set( _gremstate, _self );
+      _rotation.set( _grotation, _self );
    }
 
    void system_contract::setrwrdratio( double stake_share, double vote_share ) {

--- a/contracts/contracts/rem.system/src/rotation.cpp
+++ b/contracts/contracts/rem.system/src/rotation.cpp
@@ -89,15 +89,14 @@ namespace eosiosystem {
       }
 
       //get top21 list and replace rotated out producer with standby if rotation pair is set
-      auto schedule = std::move(top_prods);
       if (_grotation.bp_out != name(0) && _grotation.sbp_in != name(0)) {
-         const auto bp_it = std::find_if(std::begin(schedule), std::end(schedule),
+         const auto bp_it = std::find_if(std::begin(top_prods), std::end(top_prods),
             [this](const auto& prod_key) { return prod_key.producer_name == _grotation.bp_out; });
-         if (bp_it != std::end(schedule)) {
+         if (bp_it != std::end(top_prods)) {
             const auto& prod = _producers.get(_grotation.sbp_in.value);
             *bp_it = eosio::producer_key{ prod.owner, prod.producer_key };
          }
       }
-      return schedule;
+      return top_prods;
    }
 } /// namespace eosiosystem

--- a/contracts/contracts/rem.system/src/rotation.cpp
+++ b/contracts/contracts/rem.system/src/rotation.cpp
@@ -3,100 +3,110 @@
 
 namespace eosiosystem {
 
-   std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {
-      //update rotation structure
-      auto sortedprods = _producers.get_index<"prototalvote"_n>();
-      std::vector<eosio::producer_key> top_prods; //top21 producers
-      std::vector<name> rotating_standby; //first n standby producers
-      std::deque<name> prods_by_rotation_time; //queue of producers to rotate out (from first to last)
-      std::deque<name> standby_prods_by_rotation_time; //queue of standby producers to rotate in (from first to last)
-      top_prods.reserve(max_block_producers);
-      auto prod_it = sortedprods.begin();
-      for (; top_prods.size() < max_block_producers &&
-             prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
-         //fill top21 list
-         top_prods.push_back(eosio::producer_key{ prod_it->owner, prod_it->producer_key });
-         //see if producer has just became top21
-         // if so then add it to prods_by_rotation_time
-         // this way fresh top21 producers will be rotated out after old ones
-         if (std::find(std::begin(_grotation.prods_by_rotation_time), std::end(_grotation.prods_by_rotation_time), prod_it->owner) ==
-             std::end(_grotation.prods_by_rotation_time)) {
-            //insert new producers
-            prods_by_rotation_time.push_back(prod_it->owner);
-         }
-      }
-      if (top_prods.size() == max_block_producers) {
-         for (; rotating_standby.size() < _grotation.standby_prods_to_rotate &&
-                prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
-            //fill standby producers list
-            rotating_standby.push_back(prod_it->owner);
-            //see if producer has just became top n standby producer (by default top22-25)
-            // if so then add it to standby_prods_by_rotation_time
-            // this way fresh stabdby producers will be rotated in after old ones
-            if (std::find(std::begin(_grotation.standby_prods_by_rotation_time), std::end(_grotation.standby_prods_by_rotation_time), prod_it->owner) ==
-                std::end(_grotation.standby_prods_by_rotation_time)) {
-               //insert new standby producers
-               standby_prods_by_rotation_time.push_back(prod_it->owner);
-            }
-         }
-      }
-      //add persisted top21 producers at the beginning of prods_by_rotation_time
-      // so they will rotate out before fresh ones
-      for (auto it = std::rbegin(_grotation.prods_by_rotation_time); it != std::rend(_grotation.prods_by_rotation_time); it++) {
-         if (std::find_if(std::begin(top_prods), std::end(top_prods),
-                          [&](const auto& prod_key) { return prod_key.producer_name == *it; }) != std::end(top_prods)) {
-            prods_by_rotation_time.push_front(*it);
-         }
-      }
-      //add persisted top n standby producer (by default top22-25) at the beginning of standby_prods_by_rotation_time
-      // so they will rotate in before fresh ones
-      for (auto it = std::rbegin(_grotation.standby_prods_by_rotation_time); it != std::rend(_grotation.standby_prods_by_rotation_time); it++) {
-         if (std::find(std::begin(rotating_standby), std::end(rotating_standby), *it) != std::end(rotating_standby)) {
-            standby_prods_by_rotation_time.push_front(*it);
-         }
-      }
-      _grotation.prods_by_rotation_time.swap(prods_by_rotation_time);
-      _grotation.standby_prods_by_rotation_time.swap(standby_prods_by_rotation_time);
-
-
-      const auto ct = eosio::current_time_point();
-      const auto next_rotation_time = _grotation.last_rotation_time + _grotation.rotation_period;
-      if (next_rotation_time <= ct) {
-         //if enough time has passed
-         // update rotation pair
-         _grotation.bp_out = name(0);
-         _grotation.sbp_in = name(0);
-         if (!_grotation.prods_by_rotation_time.empty() && !_grotation.standby_prods_by_rotation_time.empty()) {
-            _grotation.bp_out = _grotation.prods_by_rotation_time.front();
-            _grotation.sbp_in = _grotation.standby_prods_by_rotation_time.front();
-            // move bp_out and sbp_in to the end of respective lists
-            _grotation.prods_by_rotation_time.pop_front();
-            _grotation.prods_by_rotation_time.push_back(_grotation.bp_out);
-            _grotation.standby_prods_by_rotation_time.pop_front();
-            _grotation.standby_prods_by_rotation_time.push_back(_grotation.sbp_in);
-            _grotation.last_rotation_time = ct;
-         }
-      }
-      else if (_grotation.bp_out != name(0) && _grotation.sbp_in != name(0)) { //check if we need to drop rotation pair
-         //reset rotation pair if bp_out is not in active producers or if sbp_in is not in top standby producers
-         if (std::find_if(std::begin(top_prods), std::end(top_prods),
-            [this](const auto& prod_key) { return prod_key.producer_name == _grotation.bp_out; }) == std::end(top_prods) ||
-               std::find_if(std::begin(rotating_standby), std::end(rotating_standby),
-                  [this](const auto& prod) { return prod == _grotation.sbp_in; }) == std::end(rotating_standby)) {
-            _grotation.bp_out = name(0);
-            _grotation.sbp_in = name(0);
-         }
-      }
-
-      //get top21 list and replace rotated out producer with standby if rotation pair is set
-      if (_grotation.bp_out != name(0) && _grotation.sbp_in != name(0)) {
-         const auto bp_it = std::find_if(std::begin(top_prods), std::end(top_prods),
-            [this](const auto& prod_key) { return prod_key.producer_name == _grotation.bp_out; });
-         if (bp_it != std::end(top_prods)) {
-            const auto& prod = _producers.get(_grotation.sbp_in.value);
-            *bp_it = eosio::producer_key{ prod.owner, prod.producer_key };
-         }
-      }
-      return top_prods;
+struct OnExit
+{
+   OnExit( const std::string& title, const std::vector<eosio::producer_key>& to_print ) :
+      _title{ title },
+      _prods{ to_print }
+   {
    }
+
+   ~OnExit() {
+      _print();
+   }
+
+   void _print()
+   {
+      print( _title );
+      std::for_each(
+         std::begin( _prods ), std::end( _prods ),
+         [this](const auto& prod) {
+            print( "'", prod.producer_name.to_string(), "'\t" );
+         }
+      );
+      print( "\n\n" );
+   }
+
+   std::string _title;
+   const std::vector<eosio::producer_key>& _prods;
+};
+
+
+std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {
+   auto sorted_prods = _producers.get_index<"prototalvote"_n>();
+
+   std::vector<eosio::producer_key> top21_prods;
+   top21_prods.reserve(max_block_producers);
+
+   auto prod_it = std::begin(sorted_prods);
+   for (; top21_prods.size() < max_block_producers
+         && 0 < prod_it->total_votes && prod_it->active() && prod_it != std::end(sorted_prods); ++prod_it) {
+      top21_prods.push_back( eosio::producer_key{ prod_it->owner, prod_it->producer_key } );
+   }
+
+   // nothing to rotate
+   if (top21_prods.size() < max_block_producers) {
+      return top21_prods;
+   }
+
+   // top 21-25
+   std::vector<eosio::producer_key> standby;
+   prod_it = std::prev( prod_it );
+   for (; standby.size() < _grotation.standby_prods_to_rotate + 1 // top21 + top22-25
+         && 0 < prod_it->total_votes && prod_it->active() && prod_it != std::end(sorted_prods); ++prod_it) {
+      standby.push_back( eosio::producer_key{ prod_it->owner, prod_it->producer_key } );
+   }
+
+   // still nothing to rotate
+   if ( standby.size() <= 1 ) {
+      return top21_prods;
+   }
+
+
+   std::vector<eosio::producer_key> rotation;
+
+   // first go prods which were in previous rotation
+   for(const auto& prev: _grotation.standby_rotation){
+      auto it = std::find_if(
+         std::begin(standby), std::end(standby),
+         [&prev](const auto& value) {
+            return value.producer_name == prev.producer_name;
+         }
+      ); 
+      if( it != std::end(standby) ) {
+         rotation.push_back(prev);
+      }
+   }
+
+   // then go new prods
+   for(const auto& prod: standby){
+      auto it = std::find_if(
+         std::begin(_grotation.standby_rotation), std::end(_grotation.standby_rotation),
+         [&prod](const auto& value) {
+            return value.producer_name == prod.producer_name;
+         }
+      ); 
+      if( it == std::end(_grotation.standby_rotation) ) {
+         rotation.push_back(prod);
+      }
+   }
+
+   top21_prods.back() = rotation.front();
+
+   const auto ct = eosio::current_time_point();
+   const auto next_rotation_time = _grotation.last_rotation_time + _grotation.rotation_period;
+   // not yet time for rotation
+   if (next_rotation_time <= ct) {
+      std::rotate( std::begin(rotation), std::begin(rotation) + 1, std::end(rotation) );
+   }
+
+   _grotation.last_rotation_time = ct;
+   _grotation.standby_rotation   = rotation;
+
+   OnExit printer_rota{ "Rotation: ", rotation };
+   OnExit printer_top25{ "Top25: ", standby };
+   OnExit printer_top21{ "Top21: ", top21_prods };
+   return top21_prods;
+}
+
 } /// namespace eosiosystem

--- a/contracts/contracts/rem.system/src/rotation.cpp
+++ b/contracts/contracts/rem.system/src/rotation.cpp
@@ -4,35 +4,69 @@
 namespace eosiosystem {
 
    std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {
-      const auto ct = eosio::current_time_point();
-      const auto next_rotation_time = _grotation.last_rotation_time + _grotation.rotation_period;
-
-      //get top active and standby producers
+      //update rotation structure
       auto sortedprods = _producers.get_index<"prototalvote"_n>();
-      std::vector<eosio::producer_key> top_prods;
-      std::vector<eosio::producer_key> rotating_standby;
+      std::vector<eosio::producer_key> top_prods; //top21 producers
+      std::vector<name> rotating_standby; //first n standby producers
+      std::deque<name> prods_by_rotation_time; //queue of producers to rotate out (from first to last)
+      std::deque<name> standby_prods_by_rotation_time; //queue of standby producers to rotate in (from first to last)
       top_prods.reserve(max_block_producers);
       auto prod_it = sortedprods.begin();
       for (; top_prods.size() < max_block_producers &&
-               prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
+             prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
+         //fill top21 list
          top_prods.push_back(eosio::producer_key{ prod_it->owner, prod_it->producer_key });
-      }
-      //return top_prods;
-      if (top_prods.size() == max_block_producers) {
-         rotating_standby.reserve(_grotation.standby_prods_to_rotate);
-         for (; rotating_standby.size() < _grotation.standby_prods_to_rotate &&
-                  prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
-            rotating_standby.push_back(eosio::producer_key{ prod_it->owner, prod_it->producer_key });
+         //see if producer has just became top21
+         // if so then add it to prods_by_rotation_time
+         // this way fresh top21 producers will be rotated out after old ones
+         if (std::find(std::begin(_grotation.prods_by_rotation_time), std::end(_grotation.prods_by_rotation_time), prod_it->owner) ==
+             std::end(_grotation.prods_by_rotation_time)) {
+            //insert new producers
+            prods_by_rotation_time.push_back(prod_it->owner);
          }
       }
+      if (top_prods.size() == max_block_producers) {
+         for (; rotating_standby.size() < _grotation.standby_prods_to_rotate &&
+                prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
+            //fill standby producers list
+            rotating_standby.push_back(prod_it->owner);
+            //see if producer has just became top n standby producer (by default top22-25)
+            // if so then add it to standby_prods_by_rotation_time
+            // this way fresh stabdby producers will be rotated in after old ones
+            if (std::find(std::begin(_grotation.standby_prods_by_rotation_time), std::end(_grotation.standby_prods_by_rotation_time), prod_it->owner) ==
+                std::end(_grotation.standby_prods_by_rotation_time)) {
+               //insert new standby producers
+               standby_prods_by_rotation_time.push_back(prod_it->owner);
+            }
+         }
+      }
+      //add persisted top21 producers at the beginning of prods_by_rotation_time
+      // so they will rotate out before fresh ones
+      for (auto it = std::rbegin(_grotation.prods_by_rotation_time); it != std::rend(_grotation.prods_by_rotation_time); it++) {
+         if (std::find_if(std::begin(top_prods), std::end(top_prods),
+                          [&](const auto& prod_key) { return prod_key.producer_name == *it; }) != std::end(top_prods)) {
+            prods_by_rotation_time.push_front(*it);
+         }
+      }
+      //add persisted top n standby producer (by default top22-25) at the beginning of standby_prods_by_rotation_time
+      // so they will rotate in before fresh ones
+      for (auto it = std::rbegin(_grotation.standby_prods_by_rotation_time); it != std::rend(_grotation.standby_prods_by_rotation_time); it++) {
+         if (std::find(std::begin(rotating_standby), std::end(rotating_standby), *it) != std::end(rotating_standby)) {
+            standby_prods_by_rotation_time.push_front(*it);
+         }
+      }
+      _grotation.prods_by_rotation_time.swap(prods_by_rotation_time);
+      _grotation.standby_prods_by_rotation_time.swap(standby_prods_by_rotation_time);
 
 
+      const auto ct = eosio::current_time_point();
+      const auto next_rotation_time = _grotation.last_rotation_time + _grotation.rotation_period;
       if (next_rotation_time <= ct) {
-         //update rotation pair
+         //if enough time has passed
+         // update rotation pair
          _grotation.bp_out = name(0);
          _grotation.sbp_in = name(0);
          if (!_grotation.prods_by_rotation_time.empty() && !_grotation.standby_prods_by_rotation_time.empty()) {
-            //check(false, "addsdaasada");
             _grotation.bp_out = _grotation.prods_by_rotation_time.front();
             _grotation.sbp_in = _grotation.standby_prods_by_rotation_time.front();
             // move bp_out and sbp_in to the end of respective lists
@@ -43,17 +77,18 @@ namespace eosiosystem {
             _grotation.last_rotation_time = ct;
          }
       }
-      else {
+      else if (_grotation.bp_out != name(0) && _grotation.sbp_in != name(0)) { //check if we need to drop rotation pair
          //reset rotation pair if bp_out is not in active producers or if sbp_in is not in top standby producers
          if (std::find_if(std::begin(top_prods), std::end(top_prods),
             [this](const auto& prod_key) { return prod_key.producer_name == _grotation.bp_out; }) == std::end(top_prods) ||
                std::find_if(std::begin(rotating_standby), std::end(rotating_standby),
-                  [this](const auto& prod_key) { return prod_key.producer_name == _grotation.sbp_in; }) == std::end(rotating_standby)) {
+                  [this](const auto& prod) { return prod == _grotation.sbp_in; }) == std::end(rotating_standby)) {
             _grotation.bp_out = name(0);
             _grotation.sbp_in = name(0);
          }
       }
 
+      //get top21 list and replace rotated out producer with standby if rotation pair is set
       auto schedule = std::move(top_prods);
       if (_grotation.bp_out != name(0) && _grotation.sbp_in != name(0)) {
          const auto bp_it = std::find_if(std::begin(schedule), std::end(schedule),

--- a/contracts/contracts/rem.system/src/rotation.cpp
+++ b/contracts/contracts/rem.system/src/rotation.cpp
@@ -60,9 +60,8 @@ std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {
    }
 
    // top 21-25
-   std::vector<eosio::producer_key> standby;
-   prod_it = std::prev( prod_it );
-   for (; standby.size() < _grotation.standby_prods_to_rotate + 1 // top21 + top22-25
+   std::vector<eosio::producer_key> standby;   
+   for (prod_it = std::prev( prod_it ); standby.size() < _grotation.standby_prods_to_rotate + 1 // top21 + top22-25
          && 0 < prod_it->total_votes && prod_it->active() && prod_it != std::end(sorted_prods); ++prod_it) {
       standby.push_back( eosio::producer_key{ prod_it->owner, prod_it->producer_key } );
    }
@@ -105,13 +104,12 @@ std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {
    const auto ct = eosio::current_time_point();
    const auto next_rotation_time = _grotation.last_rotation_time + _grotation.rotation_period;
 
-   // rotation is done only once per 4hours
+   // rotation is done only once per 4 hours
    if (next_rotation_time <= ct) {
       std::rotate( std::begin(rotation), std::begin(rotation) + 1, std::end(rotation) );
+      _grotation.last_rotation_time = ct;
+      _grotation.standby_rotation   = rotation;
    }
-
-   _grotation.last_rotation_time = ct;
-   _grotation.standby_rotation   = rotation;
 
    return top21_prods;
 }

--- a/contracts/contracts/rem.system/src/rotation.cpp
+++ b/contracts/contracts/rem.system/src/rotation.cpp
@@ -130,9 +130,9 @@ std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {
    _grotation.last_rotation_time = ct;
    _grotation.standby_rotation   = rotation;
 
-   OnExit printer_rota{ "Rotation: ", rotation };
-   OnExit printer_top25{ "Top25: ", standby };
-   OnExit printer_top21{ "Top21: ", top21_prods };
+   // OnExit printer_rota{ "Rotation: ", rotation };
+   // OnExit printer_top25{ "Top25: ", standby };
+   // OnExit printer_top21{ "Top21: ", top21_prods };
    return top21_prods;
 }
 

--- a/contracts/contracts/rem.system/src/rotation.cpp
+++ b/contracts/contracts/rem.system/src/rotation.cpp
@@ -6,11 +6,11 @@ namespace eosiosystem {
 /**
  * Rotation algorithm:
  *  top20 is never rotated
- *  while schedule doesn't change, rotate every 4hours each producer from top21-25
- *    first goes top21 replaceing top21
- *    then goes top22 replaceing top21
+ *  until schedule is changed, every 4hours rotate each producer from top21-25
+ *    first goes top21 replacing top21
+ *    then goes top22 replacing top21
  *    and so on..
- *  if some producer nor from current schedule top21 neither from top25 reaches top21 position 
+ *  if some producer neither from current schedule top21 nor from top25 reaches top21 position 
  *  we should not rotate him, so we reset rotation to current time point and schedule him for further rotations.
  */
 std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {

--- a/contracts/contracts/rem.system/src/rotation.cpp
+++ b/contracts/contracts/rem.system/src/rotation.cpp
@@ -1,0 +1,68 @@
+#include <rem.system/rem.system.hpp>
+
+
+namespace eosiosystem {
+
+   std::vector<eosio::producer_key> system_contract::get_rotated_schedule() {
+      const auto ct = eosio::current_time_point();
+      const auto next_rotation_time = _grotation.last_rotation_time + _grotation.rotation_period;
+
+      //get top active and standby producers
+      auto sortedprods = _producers.get_index<"prototalvote"_n>();
+      std::vector<eosio::producer_key> top_prods;
+      std::vector<eosio::producer_key> rotating_standby;
+      top_prods.reserve(max_block_producers);
+      auto prod_it = sortedprods.begin();
+      for (; top_prods.size() < max_block_producers &&
+               prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
+         top_prods.push_back(eosio::producer_key{ prod_it->owner, prod_it->producer_key });
+      }
+      //return top_prods;
+      if (top_prods.size() == max_block_producers) {
+         rotating_standby.reserve(_grotation.standby_prods_to_rotate);
+         for (; rotating_standby.size() < _grotation.standby_prods_to_rotate &&
+                  prod_it != sortedprods.end() && 0 < prod_it->total_votes && prod_it->active(); prod_it++) {
+            rotating_standby.push_back(eosio::producer_key{ prod_it->owner, prod_it->producer_key });
+         }
+      }
+
+
+      if (next_rotation_time <= ct) {
+         //update rotation pair
+         _grotation.bp_out = name(0);
+         _grotation.sbp_in = name(0);
+         if (!_grotation.prods_by_rotation_time.empty() && !_grotation.standby_prods_by_rotation_time.empty()) {
+            //check(false, "addsdaasada");
+            _grotation.bp_out = _grotation.prods_by_rotation_time.front();
+            _grotation.sbp_in = _grotation.standby_prods_by_rotation_time.front();
+            // move bp_out and sbp_in to the end of respective lists
+            _grotation.prods_by_rotation_time.pop_front();
+            _grotation.prods_by_rotation_time.push_back(_grotation.bp_out);
+            _grotation.standby_prods_by_rotation_time.pop_front();
+            _grotation.standby_prods_by_rotation_time.push_back(_grotation.sbp_in);
+            _grotation.last_rotation_time = ct;
+         }
+      }
+      else {
+         //reset rotation pair if bp_out is not in active producers or if sbp_in is not in top standby producers
+         if (std::find_if(std::begin(top_prods), std::end(top_prods),
+            [this](const auto& prod_key) { return prod_key.producer_name == _grotation.bp_out; }) == std::end(top_prods) ||
+               std::find_if(std::begin(rotating_standby), std::end(rotating_standby),
+                  [this](const auto& prod_key) { return prod_key.producer_name == _grotation.sbp_in; }) == std::end(rotating_standby)) {
+            _grotation.bp_out = name(0);
+            _grotation.sbp_in = name(0);
+         }
+      }
+
+      auto schedule = std::move(top_prods);
+      if (_grotation.bp_out != name(0) && _grotation.sbp_in != name(0)) {
+         const auto bp_it = std::find_if(std::begin(schedule), std::end(schedule),
+            [this](const auto& prod_key) { return prod_key.producer_name == _grotation.bp_out; });
+         if (bp_it != std::end(schedule)) {
+            const auto& prod = _producers.get(_grotation.sbp_in.value);
+            *bp_it = eosio::producer_key{ prod.owner, prod.producer_key };
+         }
+      }
+      return schedule;
+   }
+} /// namespace eosiosystem

--- a/contracts/contracts/rem.system/src/voting.cpp
+++ b/contracts/contracts/rem.system/src/voting.cpp
@@ -98,17 +98,7 @@ namespace eosiosystem {
    void system_contract::update_elected_producers( const block_timestamp& block_time ) {
       _gstate.last_producer_schedule_update = block_time;
 
-      auto idx = _producers.get_index<"prototalvote"_n>();
-
-      std::vector< std::pair<eosio::producer_key,uint16_t> > top_producers;
-      top_producers.reserve(max_block_producers);
-
-      // TODO rewrite in algorithm terms
-      // TODO check if we can rely on producer_info::active()
-      for ( auto it = idx.cbegin(); it != idx.cend() && top_producers.size() < 21 && 0 < it->total_votes && it->active(); ++it ) {
-         top_producers.emplace_back( std::pair<eosio::producer_key,uint16_t>({{it->owner, it->producer_key}, it->location}) );
-      }
-
+      auto top_producers = get_rotated_schedule();
       if ( top_producers.size() == 0 || top_producers.size() < _gstate.last_producer_schedule_size ) {
          return;
       }
@@ -120,7 +110,7 @@ namespace eosiosystem {
 
       producers.reserve(top_producers.size());
       for( const auto& item : top_producers )
-         producers.push_back(item.first);
+         producers.push_back(item);
 
       if( set_proposed_producers( producers ) >= 0 ) {
          _gstate.last_producer_schedule_size = static_cast<decltype(_gstate.last_producer_schedule_size)>( top_producers.size() );

--- a/contracts/contracts/rem.system/src/voting.cpp
+++ b/contracts/contracts/rem.system/src/voting.cpp
@@ -98,22 +98,16 @@ namespace eosiosystem {
    void system_contract::update_elected_producers( const block_timestamp& block_time ) {
       _gstate.last_producer_schedule_update = block_time;
 
-      auto top_producers = get_rotated_schedule();
-      if ( top_producers.size() == 0 || top_producers.size() < _gstate.last_producer_schedule_size ) {
+      auto producers = get_rotated_schedule();
+      if ( producers.size() == 0 || producers.size() < _gstate.last_producer_schedule_size ) {
          return;
       }
 
       /// sort by producer name
-      std::sort( top_producers.begin(), top_producers.end() );
-
-      std::vector<eosio::producer_key> producers;
-
-      producers.reserve(top_producers.size());
-      for( const auto& item : top_producers )
-         producers.push_back(item);
+      std::sort( producers.begin(), producers.end() );
 
       if( set_proposed_producers( producers ) >= 0 ) {
-         _gstate.last_producer_schedule_size = static_cast<decltype(_gstate.last_producer_schedule_size)>( top_producers.size() );
+         _gstate.last_producer_schedule_size = static_cast<decltype(_gstate.last_producer_schedule_size)>( producers.size() );
       }
    }
 

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -207,6 +207,44 @@ public:
         return expected_produced_blocks;
     }
 
+    uint32_t get_current_round_unpaid_blocks( const account_name& prod ) {
+        auto data = get_row_by_account(config::system_account_name, config::system_account_name, N(producers), prod);
+        if (data.empty()) {
+            return 0;
+        }
+
+        fc::variant v = abi_ser.binary_to_variant( "producer_info", data, abi_serializer_max_time );
+        uint32_t current_round_unpaid_blocks = 0;
+        fc::from_variant(v["current_round_unpaid_blocks"], current_round_unpaid_blocks);
+        return current_round_unpaid_blocks;
+    }
+
+    uint32_t get_unpaid_blocks( const account_name& prod ) {
+        auto data = get_row_by_account(config::system_account_name, config::system_account_name, N(producers), prod);
+        if (data.empty()) {
+            return 0;
+        }
+
+        fc::variant v = abi_ser.binary_to_variant( "producer_info", data, abi_serializer_max_time );
+        uint32_t unpaid_blocks = 0;
+        fc::from_variant(v["unpaid_blocks"], unpaid_blocks);
+        return unpaid_blocks;
+    }
+
+    std::pair<name, name> get_rotated_producers() {
+        auto data = get_row_by_account(config::system_account_name, config::system_account_name, N(rotations), N(rotations));
+        if (data.empty()) {
+            return std::make_pair(0, 0);
+        }
+
+        fc::variant v = abi_ser.binary_to_variant( "rotation_state", data, abi_serializer_max_time );
+        name bp_out;
+        name sbp_in;
+        fc::from_variant(v["bp_out"], bp_out);
+        fc::from_variant(v["sbp_in"], sbp_in);
+        return std::make_pair(bp_out, sbp_in);
+    }
+
     void set_code_abi(const account_name& account, const vector<uint8_t>& wasm, const char* abi, const private_key_type* signer = nullptr) {
        wdump((account));
         set_code(account, wasm, signer);
@@ -363,9 +401,24 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         // This will increase the total vote stake by (40,000,000 - 1,000)
         votepro( N(whale4), {N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
         BOOST_TEST(get_global_state()["total_activated_stake"].as<int64_t>() == 1899999996000);
+        for( auto prod : producer_candidates ) {
+            votepro(prod, { prod });
+        }
+
+        produce_blocks(4);
+        BOOST_REQUIRE(control->head_block_state()->block_num == 91);
+        for( auto prod : producer_candidates ) {
+            BOOST_REQUIRE(get_pending_pervote_reward(prod) == 0);
+            BOOST_REQUIRE(get_expected_produced_blocks(prod) == 0);
+            BOOST_REQUIRE(get_current_round_unpaid_blocks(prod) == 0);
+            BOOST_REQUIRE(get_unpaid_blocks(prod) == 0);
+        }
+
+        produce_block();
+        BOOST_REQUIRE(get_current_round_unpaid_blocks(N(prodm)) == 1);
+        BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
 
         // Since the total vote stake is more than 150,000,000, the new producer set will be set
-        produce_blocks_for_n_rounds(2); // 2 rounds since new producer schedule is set when the first block of next round is irreversible
         active_schedule = control->head_block_state()->active_schedule;
         BOOST_REQUIRE(active_schedule.producers.size() == 21);
         BOOST_TEST(active_schedule.producers.at(0).producer_name == "proda");
@@ -390,13 +443,6 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         BOOST_TEST(active_schedule.producers.at(19).producer_name == "prodt");
         BOOST_TEST(active_schedule.producers.at(20).producer_name == "produ");
         BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
-        //Rounds in this schedule are started by prodp
-        //Counters of expected_produced_blocks
-        //proda-prodd - 12
-        //prode       - 7
-        //prodf-prodo - 0
-        //prodp       - 9
-        //prodq-produ - 12
 
         BOOST_REQUIRE_THROW(base_tester::push_action(config::system_account_name, N(setrwrdratio),
                                                      config::system_account_name, mvo()("stake_share",  0.5)("vote_share", 0.5)),
@@ -435,31 +481,11 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
            BOOST_TEST(get_pending_pervote_reward(prod.producer_name) > 0);
         }
 
-        // make changes to top 21 producer list
-        votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
-                           N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
-                           N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ),
-                           N(runnerup1)} );
-        produce_block();
-        BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
         produce_blocks_until_schedule_is_changed(2000);
-        produce_blocks(2);
-        //Counters of expected_produced_blocks
-        //proda-prodf - 60
-        //prodg       - 49
-        //prodh-prodo - 48
-        //prodp       - 57
-        //prodq-produ - 60
-        for (auto prod: { N(proda), N(prodb), N(prodc) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 60);
-        }
-        BOOST_TEST(get_expected_produced_blocks(N(prodd)) == 49); //last producer in round
-        for (auto prod: { N(prode), N(prodf), N(prodg), N(prodh), N(prodi), N(prodj), N(prodk), N(prodl) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 48);
-        }
-        BOOST_TEST(get_expected_produced_blocks(N(prodm)) == 57); //first producer in round
-        for (auto prod: { N(prodn), N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 60);
+        produce_block();
+        //schedule isn`t changed so no expected_produced_blocks calculated
+        for( auto prod : producer_candidates ) {
+            BOOST_REQUIRE(get_expected_produced_blocks(prod) == 0);
         }
 
         //update active schedule so we can check pending rewards after next schedule becomes active
@@ -480,33 +506,54 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         BOOST_TEST(active_schedule.producers.at(12).producer_name == "prodm");
         BOOST_TEST(active_schedule.producers.at(13).producer_name == "prodn");
         BOOST_TEST(active_schedule.producers.at(14).producer_name == "prodo");
-        BOOST_TEST(active_schedule.producers.at(15).producer_name == "prodq");
+        BOOST_TEST(active_schedule.producers.at(15).producer_name == "prodp");
         BOOST_TEST(active_schedule.producers.at(16).producer_name == "prodr");
         BOOST_TEST(active_schedule.producers.at(17).producer_name == "prods");
         BOOST_TEST(active_schedule.producers.at(18).producer_name == "prodt");
         BOOST_TEST(active_schedule.producers.at(19).producer_name == "produ");
         BOOST_TEST(active_schedule.producers.at(20).producer_name == "runnerup1");
+        BOOST_TEST(get_rotated_producers().first == N(prodq));
+        BOOST_TEST(get_rotated_producers().second == N(runnerup1));
         BOOST_TEST(get_pending_pervote_reward(N(runnerup1)) == 0);
         BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
+
+        produce_block();
+        //Counters of expected_produced_blocks
+        //proda-prodl - 36
+        //prodm       - 45
+        //prodn-prodo - 48
+        //prodp       - 37
+        //prodq-produ - 36
+        for (auto prod: { N(proda), N(prodb), N(prodc), N(prode), N(prodf), N(prodg), N(prodh), N(prodi), N(prodj), N(prodk), N(prodl) }) {
+           BOOST_TEST(get_expected_produced_blocks(prod) == 36);
+        }
+        BOOST_TEST(get_expected_produced_blocks(N(prodm)) == 45); //first producer in round
+        for (auto prod: { N(prodn), N(prodo) }) {
+           BOOST_TEST(get_expected_produced_blocks(prod) == 48);
+        }
+        BOOST_TEST(get_expected_produced_blocks(N(prodp)) == 37); //last producer in round
+        for (auto prod: { N(prodq), N(prodr), N(prods), N(prodt), N(produ) }) {
+           BOOST_TEST(get_expected_produced_blocks(prod) == 36);
+        }
         // make changes to top 21 producer list
         votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
                            N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
                            N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ),
-                           N(runnerup1), N(runnerup2)} );
-        produce_block();
+                           N(runnerup2)} );
         BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
         produce_blocks_until_schedule_is_changed(2000);
         produce_blocks(2);
+        BOOST_TEST(get_rotated_producers().first == N(prodq));
+        BOOST_TEST(get_rotated_producers().second == N(runnerup1));
         BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
 
-        BOOST_TEST(get_expected_produced_blocks(N(prodp)) == 60); //wasn`t in second schedule, so expected_produced_blocks haven`t changed
-        BOOST_TEST(get_expected_produced_blocks(N(proda)) == 85); //last producer in round
-        for (auto prod: { N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg), N(prodh), N(prodi), N(prodj), N(prodk), N(prodl) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 84);
+        BOOST_TEST(get_expected_produced_blocks(N(prodq)) == 36); //wasn`t in second schedule, so expected_produced_blocks haven`t changed
+        for (auto prod: { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg), N(prodh), N(prodi), N(prodj), N(prodk), N(prodl) }) {
+           BOOST_TEST(get_expected_produced_blocks(prod) == 72);
         }
-        BOOST_TEST(get_expected_produced_blocks(N(prodm)) == 93);
-        for (auto prod: { N(prodn), N(prodo), N(prodq), N(prodr), N(prods), N(prodt), N(produ) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 96);
+        BOOST_TEST(get_expected_produced_blocks(N(prodm)) == 70);
+        for (auto prod: { N(prodn), N(prodo), N(prodp), N(prodr), N(prods), N(prodt), N(produ) }) {
+           BOOST_TEST(get_expected_produced_blocks(prod) == 72);
         }
         BOOST_TEST(get_expected_produced_blocks(N(runnerup1)) == 36);
 

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -437,11 +437,13 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         BOOST_TEST(active_schedule.producers.at(13).producer_name == "prodn");
         BOOST_TEST(active_schedule.producers.at(14).producer_name == "prodo");
         BOOST_TEST(active_schedule.producers.at(15).producer_name == "prodp");
-        BOOST_TEST(active_schedule.producers.at(16).producer_name == "prodq");
-        BOOST_TEST(active_schedule.producers.at(17).producer_name == "prodr");
-        BOOST_TEST(active_schedule.producers.at(18).producer_name == "prods");
-        BOOST_TEST(active_schedule.producers.at(19).producer_name == "prodt");
-        BOOST_TEST(active_schedule.producers.at(20).producer_name == "produ");
+        BOOST_TEST(active_schedule.producers.at(16).producer_name == "prodr");
+        BOOST_TEST(active_schedule.producers.at(17).producer_name == "prods");
+        BOOST_TEST(active_schedule.producers.at(18).producer_name == "prodt");
+        BOOST_TEST(active_schedule.producers.at(19).producer_name == "produ");
+        BOOST_TEST(active_schedule.producers.at(20).producer_name == "runnerup1");
+        BOOST_TEST(get_rotated_producers().first == N(prodq));
+        BOOST_TEST(get_rotated_producers().second == N(runnerup1));
         BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
 
         BOOST_REQUIRE_THROW(base_tester::push_action(config::system_account_name, N(setrwrdratio),
@@ -480,61 +482,8 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         for (auto prod: active_schedule.producers) {
            BOOST_TEST(get_pending_pervote_reward(prod.producer_name) > 0);
         }
+        BOOST_TEST(get_pending_pervote_reward(N(prodq)) == 0);
 
-        produce_blocks_until_schedule_is_changed(2000);
-        produce_block();
-        //schedule isn`t changed so no expected_produced_blocks calculated
-        for( auto prod : producer_candidates ) {
-            BOOST_REQUIRE(get_expected_produced_blocks(prod) == 0);
-        }
-
-        //update active schedule so we can check pending rewards after next schedule becomes active
-        active_schedule = control->head_block_state()->active_schedule;
-        BOOST_REQUIRE(active_schedule.producers.size() == 21);
-        BOOST_TEST(active_schedule.producers.at(0).producer_name == "proda");
-        BOOST_TEST(active_schedule.producers.at(1).producer_name == "prodb");
-        BOOST_TEST(active_schedule.producers.at(2).producer_name == "prodc");
-        BOOST_TEST(active_schedule.producers.at(3).producer_name == "prodd");
-        BOOST_TEST(active_schedule.producers.at(4).producer_name == "prode");
-        BOOST_TEST(active_schedule.producers.at(5).producer_name == "prodf");
-        BOOST_TEST(active_schedule.producers.at(6).producer_name == "prodg");
-        BOOST_TEST(active_schedule.producers.at(7).producer_name == "prodh");
-        BOOST_TEST(active_schedule.producers.at(8).producer_name == "prodi");
-        BOOST_TEST(active_schedule.producers.at(9).producer_name == "prodj");
-        BOOST_TEST(active_schedule.producers.at(10).producer_name == "prodk");
-        BOOST_TEST(active_schedule.producers.at(11).producer_name == "prodl");
-        BOOST_TEST(active_schedule.producers.at(12).producer_name == "prodm");
-        BOOST_TEST(active_schedule.producers.at(13).producer_name == "prodn");
-        BOOST_TEST(active_schedule.producers.at(14).producer_name == "prodo");
-        BOOST_TEST(active_schedule.producers.at(15).producer_name == "prodp");
-        BOOST_TEST(active_schedule.producers.at(16).producer_name == "prodr");
-        BOOST_TEST(active_schedule.producers.at(17).producer_name == "prods");
-        BOOST_TEST(active_schedule.producers.at(18).producer_name == "prodt");
-        BOOST_TEST(active_schedule.producers.at(19).producer_name == "produ");
-        BOOST_TEST(active_schedule.producers.at(20).producer_name == "runnerup1");
-        BOOST_TEST(get_rotated_producers().first == N(prodq));
-        BOOST_TEST(get_rotated_producers().second == N(runnerup1));
-        BOOST_TEST(get_pending_pervote_reward(N(runnerup1)) == 0);
-        BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
-
-        produce_block();
-        //Counters of expected_produced_blocks
-        //proda-prodl - 36
-        //prodm       - 45
-        //prodn-prodo - 48
-        //prodp       - 37
-        //prodq-produ - 36
-        for (auto prod: { N(proda), N(prodb), N(prodc), N(prode), N(prodf), N(prodg), N(prodh), N(prodi), N(prodj), N(prodk), N(prodl) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 36);
-        }
-        BOOST_TEST(get_expected_produced_blocks(N(prodm)) == 45); //first producer in round
-        for (auto prod: { N(prodn), N(prodo) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 48);
-        }
-        BOOST_TEST(get_expected_produced_blocks(N(prodp)) == 37); //last producer in round
-        for (auto prod: { N(prodq), N(prodr), N(prods), N(prodt), N(produ) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 36);
-        }
         // make changes to top 21 producer list
         votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
                            N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
@@ -542,18 +491,34 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
                            N(runnerup2)} );
         BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
         produce_blocks_until_schedule_is_changed(2000);
-        produce_blocks(2);
+        produce_block();
+        //schedule isn`t changed so no expected_produced_blocks calculated
+        for( auto prod : producer_candidates ) {
+           BOOST_REQUIRE(get_expected_produced_blocks(prod) == 0);
+        }
+        produce_block();
         BOOST_TEST(get_rotated_producers().first == N(prodq));
         BOOST_TEST(get_rotated_producers().second == N(runnerup1));
         BOOST_REQUIRE(get_total_votepay_shares() > 0.999 && get_total_votepay_shares() <= 1.0);
 
-        BOOST_TEST(get_expected_produced_blocks(N(prodq)) == 36); //wasn`t in second schedule, so expected_produced_blocks haven`t changed
-        for (auto prod: { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg), N(prodh), N(prodi), N(prodj), N(prodk), N(prodl) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 72);
+        //Counters of expected_produced_blocks
+        //proda-prodl - 36
+        //prodm       - 45
+        //prodn-prodo - 48
+        //prodp       - 37
+        //prodr-produ - 36
+        //runnerup1   - 36
+        BOOST_TEST(get_pending_pervote_reward(N(prodq)) == 0); //prodq was rotated out
+        for (auto prod: { N(proda), N(prodb), N(prodc), N(prode), N(prodf), N(prodg), N(prodh), N(prodi), N(prodj), N(prodk), N(prodl) }) {
+            BOOST_TEST(get_expected_produced_blocks(prod) == 36);
         }
-        BOOST_TEST(get_expected_produced_blocks(N(prodm)) == 70);
-        for (auto prod: { N(prodn), N(prodo), N(prodp), N(prodr), N(prods), N(prodt), N(produ) }) {
-           BOOST_TEST(get_expected_produced_blocks(prod) == 72);
+        BOOST_TEST(get_expected_produced_blocks(N(prodm)) == 45); //first producer in round
+        for (auto prod: { N(prodn), N(prodo) }) {
+            BOOST_TEST(get_expected_produced_blocks(prod) == 48);
+        }
+        BOOST_TEST(get_expected_produced_blocks(N(prodp)) == 37); //last producer in round
+        for (auto prod: { N(prodr), N(prods), N(prodt), N(produ) }) {
+            BOOST_TEST(get_expected_produced_blocks(prod) == 36);
         }
         BOOST_TEST(get_expected_produced_blocks(N(runnerup1)) == 36);
 

--- a/unittests/rem_rotation_test.cpp
+++ b/unittests/rem_rotation_test.cpp
@@ -147,20 +147,6 @@ public:
       produce_blocks();
    };
 
-   std::pair<name, name> get_rotated_producers() {
-      auto data = get_row_by_account(config::system_account_name, config::system_account_name, N(rotations), N(rotations));
-      if (data.empty()) {
-         return std::make_pair(0, 0);
-      }
-
-      fc::variant v = abi_ser.binary_to_variant( "rotation_state", data, abi_serializer_max_time );
-      name bp_out;
-      name sbp_in;
-      fc::from_variant(v["bp_out"], bp_out);
-      fc::from_variant(v["sbp_in"], sbp_in);
-      return std::make_pair(bp_out, sbp_in);
-   }
-
    void set_code_abi(const account_name& account, const vector<uint8_t>& wasm, const char* abi, const private_key_type* signer = nullptr) {
       wdump((account));
       set_code(account, wasm, signer);

--- a/unittests/rem_rotation_test.cpp
+++ b/unittests/rem_rotation_test.cpp
@@ -1,0 +1,424 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#include <eosio/chain/abi_serializer.hpp>
+#include <eosio/testing/tester.hpp>
+
+#include <Runtime/Runtime.h>
+
+#include <fc/variant_object.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <contracts.hpp>
+
+#ifdef NON_VALIDATING_TEST
+#define TESTER tester
+#else
+#define TESTER validating_tester
+#endif
+
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+using namespace fc;
+
+using mvo = fc::mutable_variant_object;
+
+struct genesis_account {
+   account_name aname;
+   uint64_t     initial_balance;
+};
+
+ static std::vector<genesis_account> test_genesis( {
+                                              {N(b1),       100'000'000'0000ll},
+                                              {N(whale4),    40'000'000'0000ll},
+                                              {N(whale3),    30'000'000'0000ll},
+                                              {N(whale2),    20'000'000'0000ll},
+                                              {N(proda),      1'000'000'0000ll},
+                                              {N(prodb),      1'000'000'0000ll},
+                                              {N(prodc),      1'000'000'0000ll},
+                                              {N(prodd),      1'000'000'0000ll},
+                                              {N(prode),      1'000'000'0000ll},
+                                              {N(prodf),      1'000'000'0000ll},
+                                              {N(prodg),      1'000'000'0000ll},
+                                              {N(prodh),      1'000'000'0000ll},
+                                              {N(prodi),      1'000'000'0000ll},
+                                              {N(prodj),      1'000'000'0000ll},
+                                              {N(prodk),      1'000'000'0000ll},
+                                              {N(prodl),      1'000'000'0000ll},
+                                              {N(prodm),      1'000'000'0000ll},
+                                              {N(prodn),      1'000'000'0000ll},
+                                              {N(prodo),      1'000'000'0000ll},
+                                              {N(prodp),      1'000'000'0000ll},
+                                              {N(prodq),      1'000'000'0000ll},
+                                              {N(prodr),      1'000'000'0000ll},
+                                              {N(prods),      1'000'000'0000ll},
+                                              {N(prodt),      1'000'000'0000ll},
+                                              {N(produ),      1'000'000'0000ll},
+                                              {N(runnerup1),  1'000'000'0000ll},
+                                              {N(runnerup2),  1'000'000'0000ll},
+                                              {N(runnerup3),  1'000'000'0000ll},
+                                              {N(minow1),         1'100'0000ll},
+                                              {N(minow2),         1'050'0000ll},
+                                              {N(minow3),         1'050'0000ll},
+                                              {N(masses),   500'000'000'0000ll}
+                                           });
+
+class rotation_tester : public TESTER {
+public:
+   void deploy_contract( bool call_init = true ) {
+      set_code( config::system_account_name, contracts::rem_system_wasm() );
+      set_abi( config::system_account_name, contracts::rem_system_abi().data() );
+      if( call_init ) {
+         base_tester::push_action(config::system_account_name, N(init),
+                                  config::system_account_name,  mutable_variant_object()
+                                     ("version", 0)
+                                     ("core", CORE_SYM_STR)
+         );
+      }
+      const auto& accnt = control->db().get<account_object,by_name>( config::system_account_name );
+      abi_def abi;
+      BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
+      abi_ser.set_abi(abi, abi_serializer_max_time);
+   }
+
+   fc::variant get_global_state() {
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(global), N(global) );
+      if (data.empty()) std::cout << "\nData is empty\n" << std::endl;
+      return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "eosio_global_state", data, abi_serializer_max_time );
+   }
+
+   auto delegate_bandwidth( name from, name receiver, asset stake_quantity, uint8_t transfer = 1) {
+      auto r = base_tester::push_action(config::system_account_name, N(delegatebw), from, mvo()
+         ("from", from )
+         ("receiver", receiver)
+         ("stake_quantity", stake_quantity)
+         ("transfer", transfer)
+      );
+      produce_block();
+      return r;
+   }
+
+   void create_currency( name contract, name manager, asset maxsupply, const private_key_type* signer = nullptr ) {
+      auto act =  mutable_variant_object()
+         ("issuer",       manager )
+         ("maximum_supply", maxsupply );
+
+      base_tester::push_action(contract, N(create), contract, act );
+   }
+
+   auto issue( name contract, name manager, name to, asset amount ) {
+      auto r = base_tester::push_action( contract, N(issue), manager, mutable_variant_object()
+         ("to",      to )
+         ("quantity", amount )
+         ("memo", "")
+      );
+      produce_block();
+      return r;
+   }
+
+   auto set_privileged( name account ) {
+      auto r = base_tester::push_action(config::system_account_name, N(setpriv), config::system_account_name,  mvo()("account", account)("is_priv", 1));
+      produce_block();
+      return r;
+   }
+
+   auto register_producer(name producer) {
+      auto r = base_tester::push_action(config::system_account_name, N(regproducer), producer, mvo()
+         ("producer",  name(producer))
+         ("producer_key", get_public_key( producer, "active" ) )
+         ("url", "" )
+         ("location", 0 )
+      );
+      produce_block();
+      return r;
+   }
+
+   std::pair<name, name> get_rotated_producers() {
+      auto data = get_row_by_account(config::system_account_name, config::system_account_name, N(rotations), N(rotations));
+      if (data.empty()) {
+         return std::make_pair(0, 0);
+      }
+
+      fc::variant v = abi_ser.binary_to_variant( "rotation_state", data, abi_serializer_max_time );
+      name bp_out;
+      name sbp_in;
+      fc::from_variant(v["bp_out"], bp_out);
+      fc::from_variant(v["sbp_in"], sbp_in);
+      return std::make_pair(bp_out, sbp_in);
+   }
+
+   void set_code_abi(const account_name& account, const vector<uint8_t>& wasm, const char* abi, const private_key_type* signer = nullptr) {
+      wdump((account));
+      set_code(account, wasm, signer);
+      set_abi(account, abi, signer);
+      if (account == config::system_account_name) {
+         const auto& accnt = control->db().get<account_object,by_name>( account );
+         abi_def abi_definition;
+         BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi_definition), true);
+         abi_ser.set_abi(abi_definition, abi_serializer_max_time);
+      }
+      produce_blocks();
+   }
+
+   uint32_t produce_blocks_until_schedule_is_changed(const uint32_t max_blocks) {
+      const auto current_version = control->active_producers().version;
+      uint32_t blocks_produced = 0;
+      while (control->active_producers().version == current_version && blocks_produced < max_blocks) {
+         produce_block();
+         blocks_produced++;
+      }
+      return blocks_produced;
+   }
+
+   void test_schedule(const std::vector<std::string>& expected_schedule) {
+       const auto active_schedule = control->head_block_state()->active_schedule;
+       BOOST_REQUIRE(active_schedule.producers.size() == expected_schedule.size());
+       for (size_t i = 0; i < expected_schedule.size(); i++) {
+           BOOST_TEST(active_schedule.producers.at(i).producer_name == expected_schedule.at(i));
+       }
+   }
+
+
+   abi_serializer abi_ser;
+};
+
+BOOST_AUTO_TEST_SUITE(rotation_tests)
+
+BOOST_FIXTURE_TEST_CASE( rotation_with_less_than_4_standby_test, rotation_tester ) {
+    try {
+
+        // Create rem.msig and rem.token
+        create_accounts({N(rem.msig), N(rem.token), N(rem.ram), N(rem.ramfee), N(rem.stake), N(rem.vpay), N(rem.spay), N(rem.saving) });
+        set_code_abi(N(rem.msig),
+                     contracts::rem_msig_wasm(),
+                     contracts::rem_msig_abi().data());//, &rem_active_pk);
+        set_code_abi(N(rem.token),
+                     contracts::rem_token_wasm(),
+                     contracts::rem_token_abi().data()); //, &rem_active_pk);
+
+        // Set privileged for rem.msig and rem.token
+        set_privileged(N(rem.msig));
+        set_privileged(N(rem.token));
+
+
+        // Create SYS tokens in rem.token, set its manager as rem
+        auto max_supply = core_from_string("1000000000.0000");
+        auto initial_supply = core_from_string("900000000.0000");
+        create_currency(N(rem.token), config::system_account_name, max_supply);
+        // Issue the genesis supply of 1 billion SYS tokens to rem.system
+        issue(N(rem.token), config::system_account_name, config::system_account_name, initial_supply);
+
+        // Create genesis accounts
+        for( const auto& a : test_genesis ) {
+            create_account( a.aname, config::system_account_name );
+        }
+
+        deploy_contract();
+
+        // Buy ram and stake cpu and net for each genesis accounts
+        for( const auto& a : test_genesis ) {
+            auto stake_quantity = a.initial_balance - 1000;
+
+            auto r = delegate_bandwidth(N(rem.stake), a.aname, asset(stake_quantity));
+            BOOST_REQUIRE( !r->except_ptr );
+        }
+
+
+        // register whales as producers
+        const auto whales_as_producers = { N(b1), N(whale4), N(whale3), N(whale2) };
+        for( const auto& producer : whales_as_producers ) {
+            register_producer(producer);
+        }
+
+        auto producer_candidates = {
+            N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+            N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+            N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ),
+            N(runnerup1), N(runnerup2), N(runnerup3)
+        };
+
+        // Register producers
+        for( auto pro : producer_candidates ) {
+            register_producer(pro);
+        }
+
+        // Vote for producers
+        auto votepro = [&]( account_name voter, vector<account_name> producers ) {
+            std::sort( producers.begin(), producers.end() );
+            base_tester::push_action(config::system_account_name, N(voteproducer), voter, mvo()
+                ("voter",  name(voter))
+                ("proxy", name(0) )
+                ("producers", producers)
+            );
+        };
+        votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+                          N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+                          N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
+        votepro( N(whale2), {N(runnerup1), N(runnerup2), N(runnerup3)} );
+        votepro( N(whale3), {N(proda), N(prodb), N(prodc), N(prodd), N(prode)} );
+        votepro( N(whale4), {N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
+        for( auto prod : producer_candidates ) {
+            votepro(prod, { prod });
+        }
+
+        produce_blocks(4);
+        produce_block();
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodp", "prodq", "prodr", "prods", "prodt", "produ" });
+
+        produce_blocks_until_schedule_is_changed(2000);
+        produce_block();
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodp", "prodr", "prods", "prodt", "produ", "runnerup1" });
+        BOOST_TEST(get_rotated_producers().first == N(prodq)); //bp out
+        BOOST_TEST(get_rotated_producers().second == N(runnerup1)); //standby in
+
+        // make changes to top 21 producer list
+        votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+                          N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+                          N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ),
+                          N(runnerup2)} );
+        produce_blocks_until_schedule_is_changed(2000);
+        produce_blocks(2);
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodr", "prods", "prodt", "produ", "runnerup1", "runnerup2" });
+        BOOST_TEST(get_rotated_producers().first == N(prodq)); //bp out
+        BOOST_TEST(get_rotated_producers().second == N(runnerup1)); //standby in
+
+        produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(12 * 3600));
+        produce_blocks_until_schedule_is_changed(2000);
+        produce_blocks(2);
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodq", "prods", "prodt", "produ", "runnerup2", "runnerup3" });
+        BOOST_TEST(get_rotated_producers().first == N(prodr)); //bp out
+        BOOST_TEST(get_rotated_producers().second == N(runnerup3)); //standby in
+
+    } FC_LOG_AND_RETHROW()
+}
+
+BOOST_FIXTURE_TEST_CASE( rotation_cancelled_after_bp_has_been_unvoted_test, rotation_tester ) {
+    try {
+
+        // Create rem.msig and rem.token
+        create_accounts({N(rem.msig), N(rem.token), N(rem.ram), N(rem.ramfee), N(rem.stake), N(rem.vpay), N(rem.spay), N(rem.saving) });
+        set_code_abi(N(rem.msig),
+                     contracts::rem_msig_wasm(),
+                     contracts::rem_msig_abi().data());//, &rem_active_pk);
+        set_code_abi(N(rem.token),
+                     contracts::rem_token_wasm(),
+                     contracts::rem_token_abi().data()); //, &rem_active_pk);
+
+        // Set privileged for rem.msig and rem.token
+        set_privileged(N(rem.msig));
+        set_privileged(N(rem.token));
+
+
+        // Create SYS tokens in rem.token, set its manager as rem
+        auto max_supply = core_from_string("1000000000.0000");
+        auto initial_supply = core_from_string("900000000.0000");
+        create_currency(N(rem.token), config::system_account_name, max_supply);
+        // Issue the genesis supply of 1 billion SYS tokens to rem.system
+        issue(N(rem.token), config::system_account_name, config::system_account_name, initial_supply);
+
+        // Create genesis accounts
+        for( const auto& a : test_genesis ) {
+            create_account( a.aname, config::system_account_name );
+        }
+        create_account( N(runnerup4), config::system_account_name );
+        create_account( N(runnerup5), config::system_account_name );
+
+        deploy_contract();
+
+        // Buy ram and stake cpu and net for each genesis accounts
+        for( const auto& a : test_genesis ) {
+            auto stake_quantity = a.initial_balance - 1000;
+
+            auto r = delegate_bandwidth(N(rem.stake), a.aname, asset(stake_quantity));
+            BOOST_REQUIRE( !r->except_ptr );
+        }
+        delegate_bandwidth(N(rem.stake), N(runnerup4), asset(300'000'0000));
+        delegate_bandwidth(N(rem.stake), N(runnerup5), asset(300'000'0000));
+
+
+        // register whales as producers
+        const auto whales_as_producers = { N(b1), N(whale4), N(whale3), N(whale2) };
+        for( const auto& producer : whales_as_producers ) {
+            register_producer(producer);
+        }
+
+        auto producer_candidates = {
+            N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+            N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+            N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ),
+            N(runnerup1), N(runnerup2), N(runnerup3)
+        };
+
+        // Register producers
+        for( auto pro : producer_candidates ) {
+            register_producer(pro);
+        }
+        register_producer(N(runnerup4));
+        register_producer(N(runnerup5));
+
+        // Vote for producers
+        auto votepro = [&]( account_name voter, vector<account_name> producers ) {
+            std::sort( producers.begin(), producers.end() );
+            base_tester::push_action(config::system_account_name, N(voteproducer), voter, mvo()
+                ("voter",  name(voter))
+                ("proxy", name(0) )
+                ("producers", producers)
+            );
+        };
+        votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+                          N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+                          N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
+        votepro( N(whale2), {N(runnerup1), N(runnerup2), N(runnerup3)} );
+        votepro( N(whale3), {N(proda), N(prodb), N(prodc), N(prodd), N(prode)} );
+        votepro( N(whale4), {N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
+        for( auto prod : producer_candidates ) {
+            votepro(prod, { prod });
+        }
+
+        produce_blocks(4);
+        produce_block();
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodp", "prodq", "prodr", "prods", "prodt", "produ" });
+
+        produce_blocks_until_schedule_is_changed(2000);
+        produce_block();
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodp", "prodr", "prods", "prodt", "produ", "runnerup1" });
+        BOOST_TEST(get_rotated_producers().first == N(prodq)); //bp out
+        BOOST_TEST(get_rotated_producers().second == N(runnerup1)); //standby in
+
+        //add more standby
+        votepro( N(whale2), { N(runnerup1), N(runnerup2), N(runnerup3), N(runnerup4), N(runnerup5) } );
+
+        // make changes to top 21 producer list
+        votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
+                          N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
+                          N(prodo), N(prodp), N(prodr), N(prods), N(prodt), N(produ),
+                          N(runnerup3)} );
+        produce_blocks_until_schedule_is_changed(2000);
+        produce_blocks(2);
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodp", "prodr", "prods", "prodt", "produ", "runnerup3" });
+        BOOST_TEST(get_rotated_producers().first == name(0)); //bp out
+        BOOST_TEST(get_rotated_producers().second == name(0)); //standby in
+
+        produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(12 * 3600));
+        produce_blocks_until_schedule_is_changed(2000);
+        produce_blocks(2);
+        test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
+                        "prodl", "prodm", "prodn", "prodo", "prodp", "prods", "prodt", "produ", "runnerup2", "runnerup3" });
+        BOOST_TEST(get_rotated_producers().first == N(prodr)); //bp out
+        BOOST_TEST(get_rotated_producers().second == N(runnerup2)); //standby in
+
+    } FC_LOG_AND_RETHROW()
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/rem_rotation_test.cpp
+++ b/unittests/rem_rotation_test.cpp
@@ -435,7 +435,6 @@ BOOST_FIXTURE_TEST_CASE( rotation_cancelled_after_bp_has_been_unvoted_test, rota
         produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(12 * 3600));
         produce_blocks_until_schedule_is_changed(2000);
         produce_blocks(2);
-        return;
         test_schedule({ "proda", "prodb", "prodc", "prodd", "prode", "prodf", "prodg", "prodh", "prodi", "prodj", "prodk",
                         "prodl", "prodm", "prodn", "prodo", "prodp", "prods", "prodt", "produ", "runnerup2", "runnerup3" });
         BOOST_TEST(get_rotated_producers().first == N(prodr)); //bp out

--- a/unittests/rem_rotation_test.cpp
+++ b/unittests/rem_rotation_test.cpp
@@ -170,15 +170,6 @@ public:
        return blocks_produced;
    }
 
-   void test_schedule(const std::vector<std::string>& expected_schedule) {
-       const auto active_schedule = control->head_block_state()->active_schedule;
-       BOOST_REQUIRE(active_schedule.producers.size() == expected_schedule.size());
-       for (size_t i = 0; i < expected_schedule.size(); i++) {
-           BOOST_TEST(active_schedule.producers.at(i).producer_name == expected_schedule.at(i));
-       }
-   }
-
-
    abi_serializer abi_ser;
 };
 


### PR DESCRIPTION
- [ x ] Consensus Changes

Implemented rotation mechanics.
Every twelve hours new rotation will be set.
Rotation is replacement of one of top21 producers with one of n first standby producers.
Top producers are placed in rotation queue where first is the one that was longer than others. The same is for standby queue.

If either rotated out top21 producer stopped beeing top21 or rotated in standby producer stopped beeing in rotated standby list (became top21 or moved out of top(21+n)) during rotation period then rotation pair is dropped and new schedule will be proposed with all top21 in it.