### PR TITLE
Feature/remcli able print remme specific info

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -98,6 +98,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_currency_balance, 200),
       CHAIN_RO_CALL(get_currency_stats, 200),
       CHAIN_RO_CALL(get_producers, 200),
+      CHAIN_RO_CALL(get_voters, 200),
       CHAIN_RO_CALL(get_producer_schedule, 200),
       CHAIN_RO_CALL(get_scheduled_transactions, 200),
       CHAIN_RO_CALL(abi_json_to_bin, 200),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1691,6 +1691,9 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
                boost::make_tuple(secondary_table_id->id, lower.value)));
    }();
 
+   const auto voter_table_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, config::system_account_name, N(voters) ));
+   const auto &idx = d.get_index<key_value_index, by_scope_primary>();
+
    for( ; it != secondary_index_by_secondary.end() && it->t_id == secondary_table_id->id; ++it ) {
       if (result.rows.size() >= p.limit || fc::time_point::now() > stopTime) {
          result.more = name{it->primary_key}.to_string();
@@ -1705,21 +1708,15 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
          data_var = fc::variant( data );
       }
 
-      auto t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( config::system_account_name, config::system_account_name, N(voters) ));
-      if (t_id != nullptr) {
-         const auto &idx = d.get_index<key_value_index, by_scope_primary>();
-         auto voter_it = idx.find(boost::make_tuple( t_id->id, name{it->primary_key} ));
+      // we do not inject voter info into binary representation to not break ABI
+      if (p.json && voter_table_id != nullptr) {
+         auto voter_it = idx.find(boost::make_tuple( voter_table_id->id, name{it->primary_key} ));
+
          if ( voter_it != idx.end() ) {
             vector<char> data;
             copy_inline_row(*voter_it, data);
 
-            fc::variant voter_info;
-            if (p.json) {
-               voter_info = abis.binary_to_variant(abis.get_table_type(N(voters)), data, abi_serializer_max_time, shorten_abi_errors);
-            } else {
-               voter_info = fc::variant(data);
-            }
-
+            fc::variant voter_info = abis.binary_to_variant(abis.get_table_type(N(voters)), data, abi_serializer_max_time, shorten_abi_errors);
             data_var = fc::mutable_variant_object(std::move(data_var))
                ("vote_mature_time", voter_info["vote_mature_time"])
                ("last_reassertion_time", voter_info["last_reassertion_time"]);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1720,7 +1720,9 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
                voter_info = fc::variant(data);
             }
 
-            data_var = fc::mutable_variant_object(std::move(data_var))("voter", fc::variant(voter_info));
+            data_var = fc::mutable_variant_object(std::move(data_var))
+               ("vote_mature_time", voter_info["vote_mature_time"])
+               ("last_reassertion_time", voter_info["last_reassertion_time"]);
          }
       }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1691,14 +1691,12 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
                boost::make_tuple(secondary_table_id->id, lower.value)));
    }();
 
-
    for( ; it != secondary_index_by_secondary.end() && it->t_id == secondary_table_id->id; ++it ) {
       if (result.rows.size() >= p.limit || fc::time_point::now() > stopTime) {
          result.more = name{it->primary_key}.to_string();
          break;
       }
       copy_inline_row(*kv_index.find(boost::make_tuple(table_id->id, it->primary_key)), data);
-
       if (p.json)
          result.rows.emplace_back( abis.binary_to_variant( abis.get_table_type(N(producers)), data, abi_serializer_max_time, shorten_abi_errors ) );
       else
@@ -1750,7 +1748,6 @@ read_only::get_voters_result read_only::get_voters( const read_only::get_voters_
 
          copy_inline_row(*it, data);
          if (p.json)
-         
             result.rows.emplace_back( abis.binary_to_variant( abis.get_table_type(N(voters)), data, abi_serializer_max_time, shorten_abi_errors ) );
          else
             result.rows.emplace_back(fc::variant(data));         
@@ -1762,7 +1759,6 @@ read_only::get_voters_result read_only::get_voters( const read_only::get_voters_
       fc::variant row = fc::mutable_variant_object()("error", "Internal error");
       result.rows.push_back(row);
    }
-
 
    return result;
 }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1721,6 +1721,52 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
    return result;
 }
 
+read_only::get_voters_result read_only::get_voters( const read_only::get_voters_params& p ) const {
+   get_voters_result result;
+   try{   
+      const abi_def abi = eosio::chain_apis::get_abi(db, config::system_account_name);
+      
+      const auto table_type = get_table_type(abi, N(voters));
+      const abi_serializer abis{ abi, abi_serializer_max_time };
+      EOS_ASSERT(table_type == KEYi64, chain::contract_table_query_exception, "Invalid table type ${type} for table voters", ("type",table_type));
+
+      const auto& d = db.db();
+      const auto* const table_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(config::system_account_name, config::system_account_name, N(voters)));
+      const auto& kv_index = d.get_index<key_value_index, by_scope_primary>();
+
+      const auto stopTime = fc::time_point::now() + fc::microseconds(1000 * 10); // 10ms
+      vector<char> data;
+
+      const auto lower = name{p.lower_bound};
+      auto it = kv_index.lower_bound(boost::make_tuple(table_id->id, lower.value));
+
+      for( ; it != kv_index.end(); ++it ) {
+         if (result.rows.size() >= p.limit || fc::time_point::now() > stopTime) {
+            result.more = name{it->primary_key}.to_string();
+            break;
+         }
+
+         copy_inline_row(*it, data);
+         if (p.json)
+            result.rows.emplace_back( abis.binary_to_variant( abis.get_table_type(N(voters)), data, abi_serializer_max_time, shorten_abi_errors ) );
+         else
+            result.rows.emplace_back(fc::variant(data));         
+      }
+
+      fc::variant row = fc::mutable_variant_object()("error", "No error");
+      result.rows.push_back(row);
+   }
+   catch (...) {
+      FC_LOG_MESSAGE(error, "Exception in: ${func}", ("func",__FUNCTION__));
+
+      fc::variant row = fc::mutable_variant_object()("error", "Internal error");
+      result.rows.push_back(row);
+   }
+
+
+   return result;
+}
+
 read_only::get_producer_schedule_result read_only::get_producer_schedule( const read_only::get_producer_schedule_params& p ) const {
    read_only::get_producer_schedule_result result;
    to_variant(db.active_producers(), result.active);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1718,7 +1718,7 @@ read_only::get_producers_result read_only::get_producers( const read_only::get_p
 
             fc::variant voter_info = abis.binary_to_variant(abis.get_table_type(N(voters)), data, abi_serializer_max_time, shorten_abi_errors);
             data_var = fc::mutable_variant_object(std::move(data_var))
-               ("vote_mature_time", voter_info["vote_mature_time"])
+               ("stake_lock_time", voter_info["stake_lock_time"])
                ("last_reassertion_time", voter_info["last_reassertion_time"]);
          }
       }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -358,6 +358,19 @@ public:
 
    get_producers_result get_producers( const get_producers_params& params )const;
 
+   struct get_voters_params {
+      bool        json = false;
+      string      lower_bound;
+      uint32_t    limit = 50;
+   };
+
+   struct get_voters_result {
+      vector<fc::variant> rows; ///< one row per item, either encoded as hex string or JSON object
+      string              more; ///< fill lower_bound with this value to fetch more rows
+   };
+
+   get_voters_result get_voters( const read_only::get_voters_params& p ) const;
+
    struct get_producer_schedule_params {
    };
 
@@ -750,6 +763,9 @@ FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_result, (supply)(ma
 
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_result, (rows)(total_producer_vote_weight)(more) );
+
+FC_REFLECT( eosio::chain_apis::read_only::get_voters_params,    (json)(lower_bound)(limit) )
+FC_REFLECT( eosio::chain_apis::read_only::get_voters_result,    (rows)(more) );
 
 FC_REFLECT_EMPTY( eosio::chain_apis::read_only::get_producer_schedule_params )
 FC_REFLECT( eosio::chain_apis::read_only::get_producer_schedule_result, (active)(pending)(proposed) );

--- a/programs/remcli/httpc.hpp
+++ b/programs/remcli/httpc.hpp
@@ -100,6 +100,7 @@ namespace eosio { namespace client { namespace http {
    const string get_currency_balance_func = chain_func_base + "/get_currency_balance";
    const string get_currency_stats_func = chain_func_base + "/get_currency_stats";
    const string get_producers_func = chain_func_base + "/get_producers";
+   const string get_voters_func = chain_func_base + "/get_voters";
    const string get_schedule_func = chain_func_base + "/get_producer_schedule";
    const string get_required_keys = chain_func_base + "/get_required_keys";
 

--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -1228,8 +1228,8 @@ struct list_producers_subcommand {
             const auto last_reassertion_time = fc::time_point_sec::from_iso_string( row["last_reassertion_time"].as_string() );
             const auto vote_is_reasserted = (last_reassertion_time + fc::days(7)) > fc::time_point::now();
 
-            const auto vote_mature_time = fc::time_point_sec::from_iso_string( row["vote_mature_time"].as_string() );
-            const auto weeks_to_mature = std::max( (vote_mature_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
+            const auto stake_lock_time = fc::time_point_sec::from_iso_string( row["stake_lock_time"].as_string() );
+            const auto weeks_to_mature = std::max( (stake_lock_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
 
             printf("%-13.13s %-57.57s %-59.59s %-12.4f %19s %15li/25\n",
                    row["owner"].as_string().c_str(),
@@ -1275,8 +1275,8 @@ struct list_voters_subcommand {
             const auto last_reassertion_time = fc::time_point_sec::from_iso_string( row["last_reassertion_time"].as_string() );
             const auto vote_is_reasserted = (last_reassertion_time + fc::days(7)) > fc::time_point::now();
 
-            const auto vote_mature_time = fc::time_point_sec::from_iso_string( row["vote_mature_time"].as_string() );
-            const auto weeks_to_mature = std::max( (vote_mature_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
+            const auto stake_lock_time = fc::time_point_sec::from_iso_string( row["stake_lock_time"].as_string() );
+            const auto weeks_to_mature = std::max( (stake_lock_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
 
             printf("%-13s %-21.21s %19s %15li/25 %s\n",
                    row["owner"].as_string().c_str(),
@@ -2262,12 +2262,12 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
             const auto last_reassertion_time = fc::time_point_sec::from_iso_string( obj["last_reassertion_time"].as_string() );
             const auto vote_is_reasserted = (last_reassertion_time + fc::days(7)) > fc::time_point::now();
 
-            const auto vote_mature_time = fc::time_point_sec::from_iso_string( obj["vote_mature_time"].as_string() );
-            const auto weeks_to_mature = std::max( (vote_mature_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
+            const auto stake_lock_time = fc::time_point_sec::from_iso_string( obj["stake_lock_time"].as_string() );
+            const auto weeks_to_mature = std::max( (stake_lock_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
 
             std::cout << std::endl << "voter info:" << std::endl
                       << indent << "vote is re-asserted: " << std::right << std::setw(20) << (vote_is_reasserted ? "yes" : "no") << std::endl
-                      << indent << "stake locked until: " << std::right << std::setw(21) << string(vote_mature_time) << std::endl
+                      << indent << "stake locked until: " << std::right << std::setw(21) << string(stake_lock_time) << std::endl
                       << indent << "weeks to vote mature: " << std::setw(16) << std::right << weeks_to_mature << "/25" << std::endl
                       << indent << "power: " << std::right << std::setw(34) << std::fixed << setprecision(3) << (1.0 -weeks_to_mature / 25.0) << std::endl;
          } else {

--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -72,6 +72,7 @@ Options:
 ```
 */
 
+#include <algorithm>
 #include <pwd.h>
 #include <string>
 #include <vector>
@@ -2201,6 +2202,14 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
             } else {
                std::cout << indent << "<not voted>" << std::endl;
             }
+
+            auto vote_mature_time = fc::time_point_sec::from_iso_string( obj["vote_mature_time"].as_string() );
+            auto weeks_to_mature = std::max( (vote_mature_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
+
+            std::cout << std::endl << "voter info:" << std::endl
+                      << indent << "stake locked until: " << std::right << std::setw(21) << string(vote_mature_time) << std::endl
+                      << indent << "weeks to vote mature: " << std::setw(16) << std::right << weeks_to_mature << "/25" << std::endl
+                      << indent << "power: " << std::right << std::setw(34) << std::fixed << setprecision(3) << weeks_to_mature / 25.0 << std::endl;
          } else {
             std::cout << "proxy:" << indent << proxy << std::endl;
          }

--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -1243,7 +1243,7 @@ struct list_voters_subcommand {
    std::string lower;
 
    list_voters_subcommand(CLI::App* actionRoot) {
-      auto list_producers = actionRoot->add_subcommand("listproducers", localized("List producers"));
+      auto list_producers = actionRoot->add_subcommand("listvoters", localized("List voters"));
       list_producers->add_flag("--json,-j", print_json, localized("Output in JSON format"));
       list_producers->add_option("-l,--limit", limit, localized("The maximum number of rows to return"));
       list_producers->add_option("-L,--lower", lower, localized("lower bound value of key, defaults to first"));
@@ -1254,14 +1254,12 @@ struct list_voters_subcommand {
             std::cout << fc::json::to_pretty_string(rawResult) << std::endl;
             return;
          }
-         auto result = rawResult.as<eosio::chain_apis::read_only::get_producers_result>();
+         auto result = rawResult.as<eosio::chain_apis::read_only::get_voters_result>();
          if ( result.rows.empty() ) {
             std::cout << "No producers found" << std::endl;
             return;
          }
-         auto weight = result.total_producer_vote_weight;
-         if ( !weight )
-            weight = 1;
+
          printf("%-13s %-57s %-59s %s\n", "Producer", "Producer key", "Url", "Scaled votes");
          for ( auto& row : result.rows )
             printf("%-13.13s %-57.57s %-59.59s %1.4f\n",

--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -2265,11 +2265,11 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
             const auto stake_lock_time = fc::time_point_sec::from_iso_string( obj["stake_lock_time"].as_string() );
             const auto weeks_to_mature = std::max( (stake_lock_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
 
-            std::cout << std::endl << "voter info:" << std::endl
-                      << indent << "vote is re-asserted: " << std::right << std::setw(20) << (vote_is_reasserted ? "yes" : "no") << std::endl
-                      << indent << "stake locked until: " << std::right << std::setw(21) << string(stake_lock_time) << std::endl
-                      << indent << "weeks to vote mature: " << std::setw(16) << std::right << weeks_to_mature << "/25" << std::endl
-                      << indent << "power: " << std::right << std::setw(34) << std::fixed << setprecision(3) << (1.0 -weeks_to_mature / 25.0) << std::endl;
+            std::cout << std::endl << "Staking info:" << std::endl
+                      << indent << "Guardian status: " << std::right << std::setw(24) << (vote_is_reasserted ? "yes" : "no") << std::endl
+                      << indent << "Stake locked until: " << std::right << std::setw(21) << string(stake_lock_time) << std::endl
+                      << indent << "Vote power maturity: " << std::setw(17) << std::right << (25-weeks_to_mature) << "/25" << std::endl
+                      << indent << "Current vote power: " << std::right << std::setw(21) << std::fixed << setprecision(3) << (1.0 -weeks_to_mature / 25.0) << std::endl;
          } else {
             std::cout << "proxy:" << indent << proxy << std::endl;
          }

--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -1223,29 +1223,18 @@ struct list_producers_subcommand {
          auto weight = result.total_producer_vote_weight;
          if ( !weight )
             weight = 1;
-         printf("%-13s %-57s %-59s %-12s %19s %15s\n", "Producer", "Producer key", "Url", "Scaled votes", "Vote is re-asserted", "Vote maturing rate");
-         for ( auto& row : result.rows ) {
-            const auto last_reassertion_time = fc::time_point_sec::from_iso_string( row["last_reassertion_time"].as_string() );
-            const auto vote_is_reasserted = (last_reassertion_time + fc::days(7)) > fc::time_point::now();
-
-            const auto stake_lock_time = fc::time_point_sec::from_iso_string( row["stake_lock_time"].as_string() );
-            const auto weeks_to_mature = std::max( (stake_lock_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
-
-            printf("%-13.13s %-57.57s %-59.59s %-12.4f %19s %15li/25\n",
+         printf("%-13s %-57s %-59s %s\n", "Producer", "Producer key", "Url", "Scaled votes");
+         for ( auto& row : result.rows )
+            printf("%-13.13s %-57.57s %-59.59s %1.4f\n",
                    row["owner"].as_string().c_str(),
                    row["producer_key"].as_string().c_str(),
                    row["url"].as_string().c_str(),
-                   row["total_votes"].as_double() / weight,
-                   (vote_is_reasserted ? "Yes" : "No"),
-                   weeks_to_mature
-                  );
-         }
+                   row["total_votes"].as_double() / weight);
          if ( !result.more.empty() )
             std::cout << "-L " << result.more << " for more" << std::endl;
       });
    }
 };
-
 
 struct list_voters_subcommand {
    bool print_json = false;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Updated output of several remcli commands \ remnonde endpoints
```
remcli system listvoters
Voter         Last vote weight      Vote is re-asserted Weeks to vote mature Staked
ccftpqpdmiuw  11231455398.536056518                  No                21/25 5602000255
copgbwnxryma  0.00000000000000000                    No                20/25 3000000000
cvxmevsnubbn  1291396011.3960106372                  No                21/25 3000000000
dbnpkekrfsnz  0.00000000000000000                    No                21/25 3000000000
deanesuclrfx  24008055647.873252868                 Yes                23/25 14092069502
dgmcpecspowp  0.00000000000000000                    No                21/25 3000000000
drlqhyzbomra  0.00000000000000000                    No                24/25 3000000000
dvvcjmkvkpsq  31983984378.531333923                 Yes                23/25 15622617783
emojvhynogvb  0.00000000000000000                    No                21/25 3000000000

v1/chain/get_voters
{
  "rows": [{
      "owner": "aboyxfqtgcft",
      "proxy": "",
      "producers": [],
      "staked": 3000000000,
      "last_vote_weight": "0.00000000000000000",
      "vote_mature_time": "2020-02-08T20:48:00.000",
      "proxied_vote_weight": "0.00000000000000000",
      "is_proxy": 0,
      "flags1": 0,
      "reserved2": 0,
      "reserved3": "0 ",
      "last_reassertion_time": "1970-01-01T00:00:00.000"
    },{
      "owner": "accountn3",
      "proxy": "",
      "producers": [],
      "staked": 5000000,
      "last_vote_weight": "0.00000000000000000",
      "vote_mature_time": "2020-02-19T13:57:10.500",
      "proxied_vote_weight": "0.00000000000000000",
      "is_proxy": 0,
      "flags1": 0,
      "reserved2": 0,
      "reserved3": "0 ",
      "last_reassertion_time": "1970-01-01T00:00:00.000"
    }
  ],
  "more": "jhjsdwijpqwd"
}


v1/chain/get_producers
{
      "owner": "xecmjfsogbfl",
      "total_votes": "0.00000000000000000",
      "producer_key": "EOS8JZhmfYo4hsetXupapKSbaoB5DPcxBHmHa1nw8oPSGCPUctpDf",
      "is_active": 1,
      "url": "testbp.remdapps.com",
      "current_round_unpaid_blocks": 0,
      "unpaid_blocks": 0,
      "expected_produced_blocks": 0,
      "last_expected_produced_blocks_update": "2019-09-12T18:58:54.500",
      "pending_perstake_reward": 9313117,
      "pending_pervote_reward": 0,
      "last_claim_time": "2019-09-12T18:58:54.500",
      "location": 0,
      "vote_mature_time": "2020-03-08T13:08:52.000",
      "last_reassertion_time": "1970-01-01T00:00:00.000"
}

remcli get account remproducer1
REM balances: 
     liquid:       174485.6452 REM
     staked:    100000000.0000 REM
     unstaking:         0.0000 REM
     total:     100174485.6452 REM

producers:
     remproducer1    

voter info:
     vote is re-asserted:                   no
     stake locked until:   2020-02-04T19:34:09
     weeks to vote mature:               20/25
     power:                              0.200


remcli system listproducers
Producer      Producer key                                              Url                                                         Scaled votes Vote is re-asserted Vote maturing rate
remproducer1  EOS5dorAyvqvG8znqAPjNGSsJsVf2eLv2xyv9veZAL5vseS2VVLsX     https://testchain.remme.io/                                 0,5183                        No              20/25
remproduce21  EOS5dorAyvqvG8znqAPjNGSsJsVf2eLv2xyv9veZAL5vseS2VVLsX     https://testchain.remme.io/remproduce21/                    0,0491                        No              20/25
remproduce22  EOS5dorAyvqvG8znqAPjNGSsJsVf2eLv2xyv9veZAL5vseS2VVLsX     https://testchain.remme.io/remproduce22/                    0,0473                        No              20/25
remproduce23  EOS5dorAyvqvG8znqAPjNGSsJsVf2eLv2xyv9veZAL5vseS2VVLsX     https://testchain.remme.io/remproduce23/                    0,0473                        No              20/25
remproduce24  EOS5dorAyvqvG8znqAPjNGSsJsVf2eLv2xyv9veZAL5vseS2VVLsX     https://testchain.remme.io/remproduce24/                    0,0473                        No              20/25
remproduce25  EOS5dorAyvqvG8znqAPjNGSsJsVf2eLv2xyv9veZAL5vseS2VVLsX     https://testchain.remme.io/remproduce25/                    0,0473                        No              20/25
```

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
