### PR TITLE
fixed vote maturity displaying

### DIFF
--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -1346,7 +1346,7 @@ struct list_voters_subcommand {
             const auto real_votes = real_vote_weight( row["last_vote_weight"].as_double(), weeks_to_mature );
 
             printf(
-               "%-13s %-27.6f %-27.6f %-19s %15li/25 %li\n",
+               "%-13s %-27.6f %-27.6f %-19s %16li/25 %li\n",
                row["owner"].as_string().c_str(),
                row["last_vote_weight"].as_double(),
                real_votes,

--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -1871,10 +1871,12 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
       if ( res.voter_info.is_object() ) {
          auto& obj = res.voter_info.get_object();
          string proxy = obj["proxy"].as_string();
+         bool voted = false;
          if ( proxy.empty() ) {
             auto& prods = obj["producers"].get_array();
+            voted = !prods.empty();
             std::cout << "producers:";
-            if ( !prods.empty() ) {
+            if ( voted ) {
                for ( size_t i = 0; i < prods.size(); ++i ) {
                   if ( i%3 == 0 ) {
                      std::cout << std::endl << indent;
@@ -1891,12 +1893,14 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
 
             const auto stake_lock_time = fc::time_point_sec::from_iso_string( obj["stake_lock_time"].as_string() );
             const auto weeks_to_mature = weeks_since_lock_time( stake_lock_time );
+            const auto last_vote_weight = obj["last_vote_weight"].as_double();
 
             std::cout << std::endl << "Staking info:" << std::endl
-                      << indent << "Guardian status: " << std::right << std::setw(24) << (is_guardian( staked, last_reassertion_time ) ? "yes" : "no") << std::endl
-                      << indent << "Stake locked until: " << std::right << std::setw(21) << string(stake_lock_time) << std::endl
-                      << indent << "Vote power maturity: " << std::setw(17) << std::right << weeks_to_mature << "/25" << std::endl
-                      << indent << "Current vote power: " << std::right << std::setw(21) << std::fixed << setprecision(3) << (weeks_to_mature / 25.0) << std::endl;
+                      << indent << "Guardian status: "      << std::right << std::setw(38) << (is_guardian( staked, last_reassertion_time ) ? "yes" : "no") << std::endl
+                      << indent << "Stake locked until: "   << std::right << std::setw(35) << string(stake_lock_time) << std::endl
+                      << indent << "Vote power maturity: "  << std::right << std::setw(31) << weeks_to_mature << "/25" << std::endl
+                      << indent << "Last vote weight: "     << std::right << std::setw(37) << std::fixed << setprecision(8) << last_vote_weight << std::endl
+                      << indent << "Adjusted vote weight: " << std::right << std::setw(33) << std::fixed << setprecision(8) << real_vote_weight( last_vote_weight ) << std::endl;
          } else {
             std::cout << "proxy:" << indent << proxy << std::endl;
          }
@@ -1906,6 +1910,7 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
       std::cout << fc::json::to_pretty_string(json) << std::endl;
    }
 }
+
 
 CLI::callback_t header_opt_callback = [](CLI::results_t res) {
    vector<string>::iterator itr;

--- a/programs/remcli/main.cpp
+++ b/programs/remcli/main.cpp
@@ -191,6 +191,24 @@ vector<string> tx_permission;
 
 eosio::client::http::http_context context;
 
+namespace {
+   auto weeks_since_lock_time( const fc::time_point_sec lock_time ) {
+      return std::max( ((lock_time - fc::time_point::now()) - fc::days(7)).count() / fc::days(7).count(), int64_t{0} );
+   }
+
+   auto is_guardian( const int64_t staked, const fc::time_point_sec last_reassertion_time ) {
+      return (staked >= config::guardian_stake_threshold) && ((last_reassertion_time + fc::days(7)) > fc::time_point::now());
+   }
+
+   auto real_vote_weight( double last_vote_weight, const int64_t weeks_to_mature ) {
+      const auto eos_weight = std::pow( 2, int64_t((fc::time_point::now().sec_since_epoch() - (config::block_timestamp_epoch / 1000)) / fc::days(7).to_seconds()) / double(52) );
+      const auto rem_weight = 1.0 - weeks_to_mature / 25.0;
+      
+      return last_vote_weight / eos_weight / rem_weight;
+   }
+
+} // namespace anonymous
+
 void add_standard_transaction_options(CLI::App* cmd, string default_permission = "") {
    CLI::callback_t parse_expiration = [](CLI::results_t res) -> bool {
       double value_s;
@@ -1318,20 +1336,17 @@ struct list_voters_subcommand {
          for ( auto& row : result.rows ) {
             const auto last_reassertion_time = fc::time_point_sec::from_iso_string( row["last_reassertion_time"].as_string() );
             const auto staked = row["staked"].as_int64();
-            const auto is_guardian = (staked >= config::guardian_stake_threshold) && ((last_reassertion_time + fc::days(7)) > fc::time_point::now());
 
             const auto stake_lock_time = fc::time_point_sec::from_iso_string( row["stake_lock_time"].as_string() );
-            const auto weeks_to_mature = std::max( (stake_lock_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
-            const auto eos_weight = std::pow( 2, int64_t((fc::time_point::now().sec_since_epoch() - (config::block_timestamp_epoch / 1000)) / fc::days(7).to_seconds()) / double(52) );
-            const auto rem_weight = 1.0 - weeks_to_mature / 25.0;
-            const auto real_votes = row["last_vote_weight"].as_double() / eos_weight / rem_weight;
+            const auto weeks_to_mature = weeks_since_lock_time( stake_lock_time );
+            const auto real_votes = real_vote_weight( row["last_vote_weight"].as_double(), weeks_to_mature );
 
             printf(
                "%-13s %-21.8f %-21.8f %-19s %15li/25 %li\n",
                row["owner"].as_string().c_str(),
                row["last_vote_weight"].as_double(),
                real_votes,
-               (is_guardian ? "Yes" : "No"),
+               (is_guardian( staked, last_reassertion_time ) ? "Yes" : "No"),
                (25 - weeks_to_mature),
                row["staked"].as_int64()
             );
@@ -1873,13 +1888,12 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
 
             const auto last_reassertion_time = fc::time_point_sec::from_iso_string( obj["last_reassertion_time"].as_string() );
             const auto staked = obj["staked"].as_int64();
-            const auto is_guardian = (staked >= config::guardian_stake_threshold) && ((last_reassertion_time + fc::days(7)) > fc::time_point::now());
 
             const auto stake_lock_time = fc::time_point_sec::from_iso_string( obj["stake_lock_time"].as_string() );
-            const auto weeks_to_mature = std::max( (stake_lock_time - fc::time_point::now()).count() / fc::days(7).count(), int64_t{0} );
+            const auto weeks_to_mature = weeks_since_lock_time( stake_lock_time );
 
             std::cout << std::endl << "Staking info:" << std::endl
-                      << indent << "Guardian status: " << std::right << std::setw(24) << (is_guardian ? "yes" : "no") << std::endl
+                      << indent << "Guardian status: " << std::right << std::setw(24) << (is_guardian( staked, last_reassertion_time ) ? "yes" : "no") << std::endl
                       << indent << "Stake locked until: " << std::right << std::setw(21) << string(stake_lock_time) << std::endl
                       << indent << "Vote power maturity: " << std::setw(17) << std::right << (25-weeks_to_mature) << "/25" << std::endl
                       << indent << "Current vote power: " << std::right << std::setw(21) << std::fixed << setprecision(3) << (1.0 -weeks_to_mature / 25.0) << std::endl;


### PR DESCRIPTION
output

```
./bin/remcli get account remproducer1
created: 2019-10-30T20:03:49.500
permissions: 
     owner     1:    1 EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8
        active     1:    1 EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8
memory: 
     quota:        16 GiB    used:     4.412 KiB  

net bandwidth: 
     staked:  250000000.0000 REM           (total stake delegated from account to self)
     delegated:       0.0000 REM           (total staked delegated to account from others)
     used:               392 bytes
     available:        68.65 TiB  
     limit:            68.65 TiB  

cpu bandwidth:
     staked:  250000000.0000 REM           (total stake delegated from account to self)
     delegated:       0.0000 REM           (total staked delegated to account from others)
     used:             3.445 ms   
     available:         3999 hr   
     limit:             3999 hr   

REM balances: 
     liquid:            0.0000 REM
     staked:    250000000.0000 REM
     unstaking:         0.0000 REM
     total:     250000000.0000 REM

producers:
     remproducer1    

Staking info:
     Guardian status:                      yes
     Stake locked until:   2020-04-27T20:03:54
     Vote power maturity:                 1/25
     Current vote power:                 0.040


./bin/remcli system listproducers
Producer      Producer key                                              Url                                                         Scaled votes
remproducer1  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,49986530
remproducer2  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,24993265
remproducer3  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,12496632
remproducer4  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,06248316
remproducer5  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,03124158
remproduce11  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,01562079
remproduce12  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00781040
remproduce13  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00390520
remproduce14  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00195260
remproduce15  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00097630
remproduce21  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00048815
remproduce22  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00024407
remproduce23  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00012204
remproduce24  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00006102
remproduce25  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00003051
remproduce31  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00001999
remproduce32  EOS7DhpwPkqYKqYijJFzGA6AcS3oufzisMKuLZ4ixdE1tZ5iueJP8                                                                 0,00001999


./bin/remcli system listvoters
Voter         Last vote weight            Adjusted vote weight        Guardian status     Vote power maturity Staked
remproduce11  3024932616172235,500000     3125000000,000003           Yes                                1/25 78125000000
remproduce12  1512466308086117,750000     1562500000,000001           Yes                                1/25 39062500000
remproduce13  756233154043058,875000      781250000,000001            Yes                                1/25 19531250000
remproduce14  378116577021529,437500      390625000,000000            Yes                                1/25 9765625000
remproduce15  189058288510764,718750      195312500,000000            Yes                                1/25 4882812500
remproduce21  94529144255382,359375       97656250,000000             No                                 1/25 2441406250
remproduce22  47264572127691,179688       48828125,000000             No                                 1/25 1220703125
remproduce23  23632286044486,027344       24414062,480000             No                                 1/25 610351562
remproduce24  11816143022243,013672       12207031,240000             No                                 1/25 305175781
remproduce25  5908071491761,937500        6103515,600000              No                                 1/25 152587890
remproduce31  3871913748700,462402        4000000,000000              No                                 1/25 100000000
remproduce32  3871913748700,462402        4000000,000000              No                                 1/25 100000000
remproduce33  3871913748700,462402        4000000,000000              No                                 1/25 100000000
remproduce34  3871913748700,462402        4000000,000000              No                                 1/25 100000000
remproduce35  3871913748700,462402        4000000,000000              No                                 1/25 100000000
```