### PR TITLE
Added swap finish status check of init action

### DIFF
--- a/contracts/contracts/rem.swap/include/rem.swap/rem.swap.hpp
+++ b/contracts/contracts/rem.swap/include/rem.swap/rem.swap.hpp
@@ -30,7 +30,11 @@ namespace eosio {
     */
    class [[eosio::contract("rem.swap")]] swap : public contract {
    public:
-      swap(name receiver, name code, datastream<const char *> ds);
+      swap(name receiver, name code, datastream<const char*> ds)
+      :contract(receiver, code, ds),
+       swap_table(get_self(), get_self().value),
+       swap_params_table(get_self(), get_self().value),
+       chains_table(get_self(), get_self().value) {}
 
       /**
        * Initiate token swap action.
@@ -202,9 +206,9 @@ namespace eosio {
       };
 
       struct [[eosio::table]] swapparams {
-         string    chain_id = "0";
-         string    eth_swap_contract_address = "0";
-         string    eth_return_chainid = "0";
+         string    chain_id;
+         string    eth_swap_contract_address;
+         string    eth_return_chainid;
 
          // explicit serialization macro is not necessary, used here only to improve compilation time
          EOSLIB_SERIALIZE( swapparams, (chain_id)(eth_swap_contract_address)(eth_return_chainid) )

--- a/contracts/contracts/rem.swap/src/system_info.cpp
+++ b/contracts/contracts/rem.swap/src/system_info.cpp
@@ -84,7 +84,7 @@ namespace eosio {
 
    bool swap::is_swap_confirmed( const vector<name>& provided_approvals ) const
    {
-      vector<name> _producers = get_producers();
+      vector<name> _producers = eosio::get_active_producers();
       uint8_t quantity_active_appr = 0;
       for (const auto& producer: provided_approvals) {
          auto prod_appr = std::find(_producers.begin(), _producers.end(), producer);


### PR DESCRIPTION
## Implement
 - Throw error at init action when the swap already finished.
 - The default parameters are removed from the `swapparams` table and output an error if the parameters are not set.