### PR TITLE
Fixed removing votes

### DIFF
--- a/contracts/contracts/rem.system/src/voting.cpp
+++ b/contracts/contracts/rem.system/src/voting.cpp
@@ -184,10 +184,10 @@ namespace eosiosystem {
          }
       }
 
-      auto new_vote_weight = 0;
+      double new_vote_weight = 0;
       
       if(producers.size()) {
-         stake2vote( voter->staked, voter->stake_lock_time ) / producers.size();
+         new_vote_weight = stake2vote( voter->staked, voter->stake_lock_time ) / producers.size();
       }
       
       if( voter->is_proxy ) {
@@ -282,7 +282,12 @@ namespace eosiosystem {
 
    void system_contract::propagate_weight_change( const voter_info& voter ) {
       check( !voter.proxy || !voter.is_proxy, "account registered as a proxy is not allowed to use a proxy" );
-      double new_weight = voter.producers.size() > 0 ? stake2vote( voter.staked, voter.stake_lock_time ) / voter.producers.size() : 0;
+      
+      double new_weight = 0;
+      
+      if(voter.producers.size()) {
+         new_weight = stake2vote( voter.staked, voter.stake_lock_time ) / voter.producers.size();
+      }
       if ( voter.is_proxy ) {
          new_weight += voter.proxied_vote_weight;
       }

--- a/contracts/contracts/rem.system/src/voting.cpp
+++ b/contracts/contracts/rem.system/src/voting.cpp
@@ -184,7 +184,12 @@ namespace eosiosystem {
          }
       }
 
-      auto new_vote_weight = producers.size() > 0 ? stake2vote( voter->staked, voter->stake_lock_time ) / producers.size() : 0;
+      auto new_vote_weight = 0;
+      
+      if(producers.size()) {
+         stake2vote( voter->staked, voter->stake_lock_time ) / producers.size();
+      }
+      
       if( voter->is_proxy ) {
          new_vote_weight += voter->proxied_vote_weight;
       }

--- a/contracts/contracts/rem.system/src/voting.cpp
+++ b/contracts/contracts/rem.system/src/voting.cpp
@@ -184,7 +184,7 @@ namespace eosiosystem {
          }
       }
 
-      auto new_vote_weight = stake2vote( voter->staked, voter->stake_lock_time ) / producers.size();
+      auto new_vote_weight = producers.size() > 0 ? stake2vote( voter->staked, voter->stake_lock_time ) / producers.size() : 0;
       if( voter->is_proxy ) {
          new_vote_weight += voter->proxied_vote_weight;
       }
@@ -277,7 +277,7 @@ namespace eosiosystem {
 
    void system_contract::propagate_weight_change( const voter_info& voter ) {
       check( !voter.proxy || !voter.is_proxy, "account registered as a proxy is not allowed to use a proxy" );
-      double new_weight = stake2vote( voter.staked, voter.stake_lock_time ) / voter.producers.size();
+      double new_weight = voter.producers.size() > 0 ? stake2vote( voter.staked, voter.stake_lock_time ) / voter.producers.size() : 0;
       if ( voter.is_proxy ) {
          new_weight += voter.proxied_vote_weight;
       }

--- a/unittests/rem_voting_test.cpp
+++ b/unittests/rem_voting_test.cpp
@@ -540,6 +540,17 @@ BOOST_FIXTURE_TEST_CASE( rem_vote_weight_test, voting_tester ) {
             BOOST_TEST_REQUIRE( 1.4880535147525217e+18 == prod["total_votes"].as_double() );
 
         }
+
+        // Test removing votes
+        {
+           const auto voter_before = get_voter_info( name("whale1") );
+           BOOST_TEST_REQUIRE( 0.0 < voter_before["last_vote_weight"].as_double() );
+           votepro( N(whale1), {} );
+
+           // last_vote_weight should be 0
+           const auto voter_after = get_voter_info( name("whale1") );
+           BOOST_TEST_REQUIRE( 0.0 == voter_after["last_vote_weight"].as_double() );
+        }
     } FC_LOG_AND_RETHROW()
 }
 


### PR DESCRIPTION
## Change Description
After removing votes `remcli system voteproducer unapprove voter producers`, last vote weight will be equal `inf` but should be equal `0` due to division by zero producers size.