### PR TITLE
Feature adjustable account price based on oracle

### DIFF
--- a/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
+++ b/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
@@ -76,7 +76,7 @@ namespace eosiosystem {
    static constexpr int64_t  default_votepay_factor        = 40000;   // per-block pay share = 10000 / 40000 = 25% of the producer pay
 
    static constexpr int64_t  min_account_ram = 3800; // 3742 bytes - is size of the new user account for current version
-   static constexpr uint64_t min_account_price = 5000; // the minimum price for creating a new account 0.5 $
+   static constexpr uint64_t account_usd_price = 5000; // the price for creating a new account in USD (default = $0.5)
 
    /**
     *

--- a/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
+++ b/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
@@ -1464,7 +1464,7 @@ namespace eosiosystem {
          static eosio_global_state get_default_parameters();
          static eosio_global_state4 get_default_inflation_parameters();
          static eosio_global_rem_state get_default_rem_parameters();
-         uint64_t get_min_account_stake();
+         uint64_t get_min_threshold_stake();
          symbol core_symbol()const;
          void update_ram_supply();
 

--- a/contracts/contracts/rem.system/src/delegate_bandwidth.cpp
+++ b/contracts/contracts/rem.system/src/delegate_bandwidth.cpp
@@ -5,6 +5,7 @@
 #include <eosio/serialize.hpp>
 #include <eosio/transaction.hpp>
 
+#include <rem.attr/rem.attr.hpp>
 #include <rem.system/rem.system.hpp>
 #include <rem.token/rem.token.hpp>
 #include <rem.oracle/rem.oracle.hpp>
@@ -101,7 +102,7 @@ namespace eosiosystem {
       {
          user_resources_table   totals_tbl( get_self(), receiver.value );
          auto tot_itr = totals_tbl.find( receiver.value );
-         if( tot_itr ==  totals_tbl.end() ) {
+         if( tot_itr == totals_tbl.end() ) {
             tot_itr = totals_tbl.emplace( from, [&]( auto& tot ) {
                   tot.owner = receiver;
                   tot.net_weight    = stake_delta;
@@ -118,7 +119,13 @@ namespace eosiosystem {
                      tot.own_stake_amount += stake_delta.amount;
 
                      // we have to decrease free bytes in case of own stake
-                     const int64_t new_free_stake_amount = std::min( static_cast< int64_t >(min_account_stake) - tot.own_stake_amount, tot.free_stake_amount);
+                     int64_t discount = 0;
+                     if ( eosio::attribute::has_attribute( _gremstate.gifter_attr_contract, _gremstate.gifter_attr_issuer, source_stake_from, _gremstate.gifter_attr_name ) ) {
+                        discount = eosio::attribute::get_attribute<int64_t>(_gremstate.gifter_attr_contract, _gremstate.gifter_attr_issuer, source_stake_from, _gremstate.gifter_attr_name);
+                        check( (discount >= 0) && (discount <= 100'0000), "discount value should be in range[0, 100'0000]" );
+                     }
+                     const int64_t min_stake_delta = ( _gstate.min_account_stake - min_account_stake ) * ( 1 - (discount / 100'0000.0) );
+                     const int64_t new_free_stake_amount = std::min( static_cast< int64_t >(_gstate.min_account_stake) - tot.own_stake_amount, tot.free_stake_amount + min_stake_delta);
                      tot.free_stake_amount = std::max(new_free_stake_amount, 0LL);
                   }
                });
@@ -148,10 +155,12 @@ namespace eosiosystem {
                const double bytes_per_token = (double)_gstate.max_ram_size / (double)system_token_max_supply.amount;
                const int64_t staked = tot_itr->own_stake_amount + tot_itr->free_stake_amount;
                const int64_t bytes_for_stake = bytes_per_token * staked + ram_gift_bytes( staked );
-               set_resource_limits( receiver,
-                                    ram_managed ? ram_bytes : bytes_for_stake,
-                                    net_managed ? net : tot_itr->net_weight.amount + tot_itr->free_stake_amount,
-                                    cpu_managed ? cpu : tot_itr->cpu_weight.amount + tot_itr->free_stake_amount);
+
+               ram_bytes = ram_managed ? ram_bytes : bytes_for_stake;
+               net = net_managed ? net : std::max( tot_itr->net_weight.amount + tot_itr->free_stake_amount, static_cast< int64_t >(_gstate.min_account_stake) );
+               cpu = cpu_managed ? cpu : std::max( tot_itr->cpu_weight.amount + tot_itr->free_stake_amount, static_cast< int64_t >(_gstate.min_account_stake) );
+
+               set_resource_limits( receiver, ram_bytes, net, cpu );
             }
          }
       } // tot_itr can be invalid, should go out of scope

--- a/contracts/contracts/rem.system/src/delegate_bandwidth.cpp
+++ b/contracts/contracts/rem.system/src/delegate_bandwidth.cpp
@@ -78,7 +78,7 @@ namespace eosiosystem {
          discount = eosio::attribute::get_attribute<int64_t>(_gremstate.gifter_attr_contract, _gremstate.gifter_attr_issuer, source_stake_from, _gremstate.gifter_attr_name);
          check( (discount >= 0) && (discount <= 100'0000), "discount value should be in range[0, 100'0000]" );
       }
-      const int64_t min_account_stake_delta = ( _gstate.min_account_stake - min_threshold_stake ) * ( 1 - (discount / 100'0000.0) );
+      const int64_t delta2min_account_stake = ( _gstate.min_account_stake - min_threshold_stake ) * ( 1 - (discount / 100'0000.0) );
 
       // update stake delegated from "from" to "receiver"
       {
@@ -126,14 +126,14 @@ namespace eosiosystem {
                      tot.own_stake_amount += stake_delta.amount;
 
                      // we have to decrease free bytes in case of own stake
-                     const int64_t new_free_stake_amount = std::min( static_cast< int64_t >(_gstate.min_account_stake) - tot.own_stake_amount, tot.free_stake_amount + min_account_stake_delta);
+                     const int64_t new_free_stake_amount = std::min( static_cast< int64_t >(_gstate.min_account_stake) - tot.own_stake_amount, tot.free_stake_amount + delta2min_account_stake);
                      tot.free_stake_amount = std::max(new_free_stake_amount, 0LL);
                   }
                });
          }
          check( 0 <= tot_itr->net_weight.amount, "insufficient staked total net bandwidth" );
          check( 0 <= tot_itr->cpu_weight.amount, "insufficient staked total cpu bandwidth" );
-         check( min_threshold_stake + min_account_stake_delta <= tot_itr->own_stake_amount + tot_itr->free_stake_amount, "insufficient minimal account stake for " + receiver.to_string() );
+         check( min_threshold_stake + delta2min_account_stake <= tot_itr->own_stake_amount + tot_itr->free_stake_amount, "insufficient minimal account stake for " + receiver.to_string() );
          {
             bool ram_managed = false;
             bool net_managed = false;
@@ -157,8 +157,8 @@ namespace eosiosystem {
                const int64_t bytes_for_stake = bytes_per_token * staked + ram_gift_bytes( staked );
 
                ram_bytes = ram_managed ? ram_bytes : bytes_for_stake;
-               net = net_managed ? net : std::max( tot_itr->net_weight.amount + tot_itr->free_stake_amount, static_cast< int64_t >(_gstate.min_account_stake) );
-               cpu = cpu_managed ? cpu : std::max( tot_itr->cpu_weight.amount + tot_itr->free_stake_amount, static_cast< int64_t >(_gstate.min_account_stake) );
+               net = net_managed ? net : tot_itr->net_weight.amount + tot_itr->free_stake_amount;
+               cpu = cpu_managed ? cpu : tot_itr->cpu_weight.amount + tot_itr->free_stake_amount;
 
                set_resource_limits( receiver, ram_bytes, net, cpu );
             }

--- a/contracts/contracts/rem.system/src/rem.system.cpp
+++ b/contracts/contracts/rem.system/src/rem.system.cpp
@@ -165,7 +165,7 @@ namespace eosiosystem {
       auto rem_usd_it = remprice_table.find(rem_usd_pair.value);
       auto setprice_window = eosio::seconds(remoracle::setprice_window_seconds + remoracle::setprice_window_seconds * 0.2);
       bool is_valid_price = ( rem_usd_it != remprice_table.end() ) && ( (current_time_point() - rem_usd_it->last_update.to_time_point()) <= setprice_window );
-      uint64_t oracle_min_account_stake = min_account_price / rem_usd_it->price;
+      uint64_t oracle_min_account_stake = account_usd_price / rem_usd_it->price;
 
       if ( is_valid_price && oracle_min_account_stake > 0 ) {
          return std::min(oracle_min_account_stake, _gstate.min_account_stake);

--- a/contracts/contracts/rem.system/src/rem.system.cpp
+++ b/contracts/contracts/rem.system/src/rem.system.cpp
@@ -294,10 +294,10 @@ namespace eosiosystem {
     *  who can create accounts with the creator's name as a suffix.
     *
     */
-   void system_contract::newaccount( const name&       creator,
-                            const name&       newact,
-                            ignore<authority> owner,
-                            ignore<authority> active ) {
+   void system_contract::newaccount( const name&        creator,
+                                     const name&        newact,
+                                     ignore<authority>  owner,
+                                     ignore<authority>  active ) {
 
       if( creator != get_self() ) {
          uint64_t tmp = newact.value >> 4;
@@ -332,11 +332,10 @@ namespace eosiosystem {
          // 0 - 0.0000%, 100'0000 - 100.0000%
          check( (discount >= 0) && (discount <= 100'0000), "discount value should be in range[0, 100'0000]" );
          const auto discount_rate = discount / 100'0000.0;
-         uint64_t min_account_stake = get_min_account_stake();
 
          const auto system_token_max_supply = eosio::token::get_max_supply(token_account, system_contract::get_core_symbol().code() );
          const double bytes_per_token       = (double)_gstate.max_ram_size / (double)system_token_max_supply.amount;
-         free_stake_amount                  = discount_rate * min_account_stake;
+         free_stake_amount                  = discount_rate * _gstate.min_account_stake;
          free_gift_bytes                    = bytes_per_token * free_stake_amount;
       }
 

--- a/contracts/contracts/rem.system/src/rem.system.cpp
+++ b/contracts/contracts/rem.system/src/rem.system.cpp
@@ -160,7 +160,7 @@ namespace eosiosystem {
       _gstate.min_account_stake = min_account_stake;
    }
 
-   uint64_t system_contract::get_min_account_stake() {
+   uint64_t system_contract::get_min_threshold_stake() {
       remoracle::remprice_idx remprice_table(oracle_account, oracle_account.value);
       auto rem_usd_it = remprice_table.find(rem_usd_pair.value);
       auto setprice_window = eosio::seconds(remoracle::setprice_window_seconds + remoracle::setprice_window_seconds * 0.2);

--- a/unittests/gift_resources_test.cpp
+++ b/unittests/gift_resources_test.cpp
@@ -734,7 +734,7 @@ BOOST_FIXTURE_TEST_CASE(acc_creation_with_attr_set_with_oracle_price, gift_resou
       // create account with more than min_account_stake * 8 / 10 own resources
       {
          {
-            // min_account_stake * 8 / 10 = 80 % min_account_stake + 5.0000 REM + 0.0001 REM accuracy
+            // min_account_stake * 8 / 10 = 80 % min_account_stake + 5.0000 REM
             create_account_with_resources(N(testram55555), N(testram11111), asset((min_account_stake * 8 / 10) + 5'0000), true);
 
             const auto total_stake = get_total_stake(N(testram55555));


### PR DESCRIPTION
## Change Description
#### Addition to #127 
As the price of the token increases, the price of creating a new account based on `rem.orace` will decrease (account creation price 0.5$).

After a specific token price, the minimum account stake will be too small for networking. To solve this and integrate with the discount needs to reformat the `free_stake_amount` system.