### PR TITLE
Set activated stake action

### DIFF
--- a/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
+++ b/contracts/contracts/rem.system/include/rem.system/rem.system.hpp
@@ -1217,6 +1217,14 @@ namespace eosiosystem {
          void setminstake( uint64_t min_account_stake );
 
          /**
+         * Set activated stake action.
+         *
+         * @details Set activated stake to equal minimum activated stake.
+         */
+         [[eosio::action]]
+         void setactvstake();
+
+         /**
           * Set ram rate action.
 
           * @details Sets the rate of increase of RAM in bytes per block. It is capped by the uint16_t to

--- a/contracts/contracts/rem.system/src/rem.system.cpp
+++ b/contracts/contracts/rem.system/src/rem.system.cpp
@@ -160,6 +160,12 @@ namespace eosiosystem {
       _gstate.min_account_stake = min_account_stake;
    }
 
+   void system_contract::setactvstake() {
+      require_auth( get_self() );
+
+      _gstate.total_activated_stake = min_activated_stake;
+   }
+
    uint64_t system_contract::get_min_threshold_stake() {
       remoracle::remprice_idx remprice_table(oracle_account, oracle_account.value);
       auto rem_usd_it = remprice_table.find(rem_usd_pair.value);

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -176,6 +176,12 @@ public:
        return r;
     }
 
+    auto set_activated_stake() {
+       auto r = base_tester::push_action(config::system_account_name, N(setactvstake), config::system_account_name, mvo());
+       produce_block();
+       return r;
+   }
+
     asset get_balance( const account_name& act ) {
          return get_currency_balance(N(rem.token), symbol(CORE_SYMBOL), act);
     }
@@ -564,11 +570,14 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         produce_min_num_of_blocks_to_spend_time_wo_inactive_prod( fc::days( 180 ) );
         undelegate_bandwidth(N(b1), N(b1), core_from_string("49999500.0000"));
 
+        // Test setactvstake action
+        set_activated_stake();
+        BOOST_TEST(get_global_state()["total_activated_stake"].as<int64_t>() == 150'000'000'0000);
+
         return;
         produce_blocks(7000); /// produce blocks until virutal bandwidth can acomadate a small user
         wlog("minow" );
         votepro( N(minow1), {N(p1), N(p2)} );
-
 
 // TODO: Complete this test
     } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
`setacvstake` is the action that sets `total_activated_stake` to equal `min_activated_stake`.
This is necessary for network health at a lower value `total_activated_stake` than `min_activated_stake`.

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
